### PR TITLE
Endpoint for creating a new project

### DIFF
--- a/lib/common/deep_symbolize_keys.rb
+++ b/lib/common/deep_symbolize_keys.rb
@@ -1,0 +1,18 @@
+module Common
+  class DeepSymbolizeKeys
+    def self.to_symbolized_hash(obj)
+      case obj
+      when Hash
+        result = {}
+        obj.each do |key, value|
+          result[key.to_sym] = to_symbolized_hash(value)
+        end
+        result
+      when Array
+        obj.map {|value| to_symbolized_hash(value)}
+      else
+        obj
+      end
+    end
+  end
+end

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -2,8 +2,31 @@ require 'sinatra'
 
 module DeliveryMechanism
   class WebRoutes < Sinatra::Base
+    before do
+      @use_case_factory = Dependencies.use_case_factory
+    end
+
     get '/' do
       'hello world'
     end
+
+    post '/project/create' do
+      request_body = JSON.parse(request.body.read)
+
+      use_case = @use_case_factory.get_use_case(:create_new_project)
+
+      id = use_case.execute(
+        type: request_body['type'],
+        baseline: Common::DeepSymbolizeKeys.to_symbolized_hash(request_body['baselineData'])
+      )
+
+      content_type 'application/json'
+      response.body = {
+        projectId: id
+      }.to_json
+      response.status = 200
+    end
+
+    private
   end
 end

--- a/lib/homes_england/gateway/file_project.rb
+++ b/lib/homes_england/gateway/file_project.rb
@@ -28,7 +28,7 @@ class HomesEngland::Gateway::FileProject
 
     project = HomesEngland::Domain::Project.new
     project.type = project_data['type']
-    project.data = deep_symbolize_keys(project_data['data'])
+    project.data = Common::DeepSymbolizeKeys.to_symbolized_hash(project_data['data'])
     project
   end
 

--- a/lib/homes_england/gateway/file_project.rb
+++ b/lib/homes_england/gateway/file_project.rb
@@ -10,7 +10,7 @@ class HomesEngland::Gateway::FileProject
 
     projects << {
       type: project.type,
-      data: project.data.to_json
+      data: project.data
     }
 
     File.open(@file_path, 'w') do |f|
@@ -28,7 +28,7 @@ class HomesEngland::Gateway::FileProject
 
     project = HomesEngland::Domain::Project.new
     project.type = project_data['type']
-    project.data = deep_symbolize_keys(JSON.parse(project_data['data']))
+    project.data = deep_symbolize_keys(project_data['data'])
     project
   end
 

--- a/spec/web_routes/create_new_project_spec.rb
+++ b/spec/web_routes/create_new_project_spec.rb
@@ -1,0 +1,116 @@
+require 'rspec'
+require_relative 'delivery_mechanism_spec_helper'
+
+describe 'Creating a new project' do
+  let(:create_new_project_spy) { spy(execute: project_id) }
+
+  before do
+    stub_const(
+      'HomesEngland::UseCase::CreateNewProject',
+      double(new: create_new_project_spy)
+    )
+
+    post '/project/create',
+         project_data.to_json
+  end
+
+  context 'example one' do
+    let(:project_id) { 1 }
+    let(:project_data) do
+      {
+        type: 'hif',
+        baselineData: {
+          cats: 'meow',
+          dogs: 'woof'
+        }
+      }
+    end
+
+    it 'should return a 200 response' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'should call the create_new_project use case' do
+      expect(create_new_project_spy).to have_received(:execute)
+    end
+
+    it 'should call the create_new_project use case with type' do
+      expect(create_new_project_spy).to(
+        have_received(:execute).with(
+          hash_including(type: 'hif')
+        )
+      )
+    end
+
+    it 'should create new project with baseline data' do
+      expect(create_new_project_spy).to(
+        have_received(:execute).with(
+          hash_including(baseline: {cats: 'meow', dogs: 'woof'})
+        )
+      )
+    end
+
+    it 'should return the id of the project' do
+      response_body = JSON.parse(last_response.body)
+
+      expect(response_body['projectId']).to eq(project_id)
+    end
+  end
+
+  context 'example two' do
+    let(:project_id) { 42 }
+    let(:project_data) do
+      {
+        type: 'ac',
+        baselineData: {
+          ducks: 'quack',
+          good: [
+            {
+              dogs: 'yes',
+              wasps: 'no'
+            }
+          ]
+        }
+      }
+    end
+
+    it 'should return a 200 response' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'should call the create_new_project use case' do
+      expect(create_new_project_spy).to have_received(:execute)
+    end
+
+    it 'should call the create_new_project use case with type' do
+      expect(create_new_project_spy).to(
+        have_received(:execute).with(
+          hash_including(type: 'ac')
+        )
+      )
+    end
+
+    it 'should create new project with baseline data' do
+      expected_baseline = {
+        ducks: 'quack',
+        good: [
+          {
+            dogs: 'yes',
+            wasps: 'no'
+          }
+        ]
+      }
+      expect(create_new_project_spy).to(
+        have_received(:execute).with(
+          hash_including(baseline: expected_baseline)
+        )
+      )
+    end
+
+    it 'should return the id of the project' do
+      response_body = JSON.parse(last_response.body)
+
+      expect(response_body['projectId']).to eq(project_id)
+    end
+  end
+end

--- a/spec/web_routes/delivery_mechanism_spec_helper.rb
+++ b/spec/web_routes/delivery_mechanism_spec_helper.rb
@@ -1,0 +1,13 @@
+require_relative '../spec_helper'
+require 'rack/test'
+
+ENV['RACK_ENV'] = 'test'
+
+RSpec.configure do |config|
+  config.include Rack::Test::Methods
+
+  def app(app = nil, &blk)
+    @app ||= block_given? ? app.instance_eval(&blk) : app
+    @app ||= DeliveryMechanism::WebRoutes
+  end
+end


### PR DESCRIPTION
Adds an endpoint for creating a new project with type & baseline data

This does no modification of the data, just passes it all through