### PR TITLE
Create project POST checks baseline data against existing template.

### DIFF
--- a/lib/common/deep_camelize_keys.rb
+++ b/lib/common/deep_camelize_keys.rb
@@ -1,0 +1,16 @@
+class Common::DeepCamelizeKeys
+  def self.to_camelized_hash(obj)
+    case obj
+    when Hash
+      Hash[obj.map {|k, v| [camelize_key(k), to_camelized_hash(v)]}]
+    when Array
+      obj.map {|item| to_camelized_hash(item)}
+    else
+      obj
+    end
+  end
+
+  def self.camelize_key(key)
+    key.to_s.gsub(/_(.)/) {$1.upcase}.to_sym
+  end
+end

--- a/lib/common/deep_symbolize_keys.rb
+++ b/lib/common/deep_symbolize_keys.rb
@@ -1,18 +1,16 @@
-module Common
-  class DeepSymbolizeKeys
-    def self.to_symbolized_hash(obj)
-      case obj
-      when Hash
-        result = {}
-        obj.each do |key, value|
-          result[key.to_sym] = to_symbolized_hash(value)
-        end
-        result
-      when Array
-        obj.map {|value| to_symbolized_hash(value)}
-      else
-        obj
+class Common::DeepSymbolizeKeys
+  def self.to_symbolized_hash(obj)
+    case obj
+    when Hash
+      result = {}
+      obj.each do |key, value|
+        result[key.to_sym] = to_symbolized_hash(value)
       end
+      result
+    when Array
+      obj.map {|value| to_symbolized_hash(value)}
+    else
+      obj
     end
   end
 end

--- a/lib/common/namespaces.rb
+++ b/lib/common/namespaces.rb
@@ -1,0 +1,1 @@
+module Common; end

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -20,10 +20,12 @@ module DeliveryMechanism
 
       return_project = @use_case_factory.get_use_case(:find_project).execute(id: params['id'].to_i)
 
+      return 404 if return_project.nil?
+
       content_type 'application/json'
       response.body = {
         type: return_project.type,
-        data: return_project.data
+        data: Common::DeepCamelizeKeys.to_camelized_hash(return_project.data)
       }.to_json
       response.status = 200
     end

--- a/lib/homes_england/domain/template.rb
+++ b/lib/homes_england/domain/template.rb
@@ -1,0 +1,7 @@
+class HomesEngland::Domain::Template
+  attr_reader :layout
+
+  def initialize (layout:)
+    @layout = layout
+  end
+end

--- a/lib/homes_england/gateway/in_memory_template.rb
+++ b/lib/homes_england/gateway/in_memory_template.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+class HomesEngland::Gateway::InMemoryTemplate
+  def initialize; end
+
+  def get_template(type:)
+    return nil unless type == 'hif'
+    HomesEngland::Domain::Template.new(
+      layout: {
+        summary: {
+          project_name: nil,
+          description: nil,
+          lead_authority: nil,
+          status: 'On Schedule'
+        },
+        infrastructure: {
+          type: nil,
+          description: nil,
+          completion_date: nil
+        },
+        financial: {
+          date: nil,
+          funded_through_HIF: nil
+        }
+      }
+    )
+  end
+end

--- a/lib/homes_england/use_case/create_new_project.rb
+++ b/lib/homes_england/use_case/create_new_project.rb
@@ -1,13 +1,18 @@
-class HomesEngland::UseCase::CreateNewProject
+# frozen_string_literal: true
 
-  def initialize(project_gateway:)
+class HomesEngland::UseCase::CreateNewProject
+  def initialize(project_gateway:, populate_template_use_case:)
     @project_gateway = project_gateway
+    @populate_template = populate_template_use_case
   end
 
   def execute(type:, baseline:)
+
+    populated_data = @populate_template.execute(type: type, baseline: baseline)
+
     project = HomesEngland::Domain::Project.new
     project.type = type
-    project.data = baseline
+    project.data = populated_data[:populated_data]
 
     id = @project_gateway.create(project)
 

--- a/lib/homes_england/use_case/populate_template.rb
+++ b/lib/homes_england/use_case/populate_template.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+class HomesEngland::UseCase::PopulateTemplate
+  def initialize(template_gateway:)
+    @template_gateway = template_gateway
+  end
+
+  def execute(type:, baseline:)
+    template = @template_gateway.get_template(type: type)
+    populated_data = populate_hash(template.layout.dup, baseline)
+    {
+      populated_data: populated_data
+    }
+  end
+
+  private
+
+  def populate_hash(base, data)
+    base.each do |key, value|
+      next if data[key].nil?
+      base[key] = get_data_value(base, data, key, value)
+    end
+  end
+
+  def get_data_value(base, data, key, value)
+    case base[key]
+    when Hash
+      populate_hash(value, data[key])
+    else
+      data[key]
+    end
+  end
+end

--- a/lib/homes_england/use_cases.rb
+++ b/lib/homes_england/use_cases.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HomesEngland::UseCases
   def self.register(builder)
     builder.define_use_case :project_gateway do
@@ -6,9 +8,15 @@ class HomesEngland::UseCases
       )
     end
 
+    builder.define_use_case :template_gateway do
+      HomesEngland::Gateway::InMemoryTemplate.new
+    end
+
+
     builder.define_use_case :create_new_project do
       HomesEngland::UseCase::CreateNewProject.new(
-        project_gateway: builder.get_use_case(:project_gateway)
+        project_gateway: builder.get_use_case(:project_gateway),
+        populate_template_use_case: builder.get_use_case(:populate_template)
       )
     end
 
@@ -21,6 +29,12 @@ class HomesEngland::UseCases
     builder.define_use_case :update_project do
       HomesEngland::UseCase::UpdateProject.new(
         project_gateway: builder.get_use_case(:project_gateway)
+      )
+    end
+
+    builder.define_use_case :populate_template do
+      HomesEngland::UseCase::PopulateTemplate.new(
+        template_gateway: builder.get_use_case(:template_gateway)
       )
     end
   end

--- a/spec/acceptance/homes_england/create_new_hif_project_spec.rb
+++ b/spec/acceptance/homes_england/create_new_hif_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec'
 require_relative '../shared_context/use_case_factory'
 
@@ -20,26 +22,33 @@ describe 'Creating a new HIF FileProject' do
         description: 'A new headquarters for all the Cats',
         lead_authority: 'Made Tech'
       },
-      infrastructures: [
-        {
-          type: 'Cat Bathroom',
-          description:'Bathroom for Cats',
-          completion_date: '2018-12-25'
-        }
-      ],
-      financials: [
-        {
-          date: '2017-12-25',
-          funded_through_HIF: true
-        }
-      ]
+      infrastructure: {
+        type: 'Cat Bathroom',
+        description: 'Bathroom for Cats',
+        completion_date: '2018-12-25'
+      },
+      financial: {
+        date: '2017-12-25',
+        funded_through_HIF: true
+      }
     }
 
-    response = get_use_case(:create_new_project).execute(type: 'hif', baseline: project_baseline)
+    summary_with_status = {
+      project_name: 'Cats Protection League',
+      description: 'A new headquarters for all the Cats',
+      lead_authority: 'Made Tech',
+      status: 'On Schedule'
+    }
+
+    response = get_use_case(:create_new_project).execute(
+      type: 'hif', baseline: project_baseline
+    )
+
     project = get_use_case(:project_gateway).find_by(id: response[:id])
 
-    expect(response[:id]).to eq(0)
     expect(project.type).to eq('hif')
-    expect(project.data).to eq(project_baseline)
+    expect(project.data[:summary]).to eq(summary_with_status)
+    expect(project.data[:infrastructure]).to eq(project_baseline[:infrastructure])
+    expect(project.data[:financial]).to eq(project_baseline[:financial])
   end
 end

--- a/spec/acceptance/homes_england/get_hif_project_spec.rb
+++ b/spec/acceptance/homes_england/get_hif_project_spec.rb
@@ -14,11 +14,46 @@ describe 'Getting a HIF project' do
   end
 
   it 'should find a project by its id' do
+    project_baseline = {
+      summary: {
+        project_name: 'Cats Protection League',
+        description: 'A new headquarters for all the Cats',
+        lead_authority: 'Made Tech'
+      },
+      infrastructure: {
+        type: 'Cat Bathroom',
+        description: 'Bathroom for Cats',
+        completion_date: '2018-12-25'
+      },
+      financial: {
+        date: '2017-12-25',
+        funded_through_HIF: true
+      }
+    }
+
+    expected_project = {
+      summary: {
+        project_name: 'Cats Protection League',
+        description: 'A new headquarters for all the Cats',
+        lead_authority: 'Made Tech',
+        status: 'On Schedule'
+      },
+      infrastructure: {
+        type: 'Cat Bathroom',
+        description: 'Bathroom for Cats',
+        completion_date: '2018-12-25'
+      },
+      financial: {
+        date: '2017-12-25',
+        funded_through_HIF: true
+      }
+    }
+
     response = get_use_case(:create_new_project).execute(type: 'hif',
-                                                         baseline: { cats: 'meow' })
+                                                         baseline: project_baseline)
     project = get_use_case(:find_project).execute(id: response[:id])
     expect(project).to_not be_nil
     expect(project.type).to eq('hif')
-    expect(project.data).to eq(cats: 'meow')
+    expect(project.data).to eq(expected_project)
   end
 end

--- a/spec/acceptance/homes_england/update_project_spec.rb
+++ b/spec/acceptance/homes_england/update_project_spec.rb
@@ -14,16 +14,29 @@ describe 'Updating a HIF Project' do
   end
 
   it 'should update a project' do
-    response = get_use_case(:create_new_project).execute(type: 'hif', baseline: { dogs: 'woof' })
-    base_project = get_use_case(:find_project).execute(id: response[:id])
-    expect(base_project.type).to eq('hif')
-    expect(base_project.data[:dogs]).to eq('woof')
+    project_baseline = {
+      summary: {
+        project_name: 'Cats Protection League',
+        description: 'A new headquarters for all the Cats',
+        lead_authority: 'Made Tech'
+      },
+      infrastructure: {
+        type: 'Cat Bathroom',
+        description: 'Bathroom for Cats',
+        completion_date: '2018-12-25'
+      },
+      financial: {
+        date: '2017-12-25',
+        funded_through_HIF: true
+      }
+    }
 
-    success = get_use_case(:update_project).execute(id: response[:id], project: { type: 'new', baseline: { cats: 'meow' } })
+    response = get_use_case(:create_new_project).execute(type: 'hif', baseline: project_baseline)
+    success = get_use_case(:update_project).execute(id: response[:id], project: { type: 'hif', baseline: { cats: 'meow' } })
     expect(success[:success]).to eq(true)
     updated_project = get_use_case(:find_project).execute(id: response[:id])
 
-    expect(updated_project.type).to eq('new')
+    expect(updated_project.type).to eq('hif')
     expect(updated_project.data[:cats]).to eq('meow')
   end
 end

--- a/spec/unit/homes_england/gateway/in_memory_template_spec.rb
+++ b/spec/unit/homes_england/gateway/in_memory_template_spec.rb
@@ -1,0 +1,13 @@
+require 'rspec'
+
+describe HomesEngland::Gateway::InMemoryTemplate do
+  it 'returns nil when given a non-hif type' do
+    template = described_class.new.get_template(type: 'abc')
+    expect(template).to be_nil
+  end
+
+  it 'returns a template given a hif type' do
+    template = described_class.new.get_template(type: 'hif')
+    expect(template).not_to be_nil
+  end
+end

--- a/spec/unit/homes_england/use_case/create_new_project_spec.rb
+++ b/spec/unit/homes_england/use_case/create_new_project_spec.rb
@@ -1,8 +1,16 @@
+# frozen_string_literal: true
+
 require 'rspec'
 
 describe HomesEngland::UseCase::CreateNewProject do
+  let(:populate_template_use_case) { double(execute: { populated_data: populated_data }) }
   let(:project_gateway) { double(create: project_id) }
-  let(:use_case) { described_class.new(project_gateway: project_gateway) }
+  let(:use_case) do
+    described_class.new(
+      project_gateway: project_gateway,
+      populate_template_use_case: populate_template_use_case
+    )
+  end
   let(:response) { use_case.execute(type: type, baseline: baseline) }
 
   before do
@@ -13,34 +21,46 @@ describe HomesEngland::UseCase::CreateNewProject do
     let(:project_id) { 0 }
     let(:type) { 'hif' }
     let(:baseline) { { key: 'value' } }
+    let(:populated_data) { { key: 'newValue' } }
 
+    it 'populate template with baseline data receives type baseline data ' do
+      expect(populate_template_use_case).to have_received(:execute)
+        .with(type: 'hif', baseline: baseline)
+    end
 
-    it 'creates the project' do
+    it 'creates the project with populated data' do
       expect(project_gateway).to have_received(:create) do |project|
         expect(project.type).to eq('hif')
-        expect(project.data).to eq({ key: 'value' })
+        expect(project.data).to eq(key: 'newValue')
       end
     end
 
     it 'returns the id from the gateway' do
-      expect(response).to eq({ id: 0 })
+      expect(response).to eq(id: 0)
     end
   end
 
   context 'example two' do
+    let(:populated_data) { { key: 'veryNewValue' } }
+
     let(:project_id) { 42 }
     let(:type) { 'cats' }
     let(:baseline) { { cat: 'meow' } }
 
+    it 'populate template with baseline data receives type baseline data ' do
+      expect(populate_template_use_case).to have_received(:execute)
+        .with(type: 'cats', baseline: baseline)
+    end
+
     it 'creates the project' do
       expect(project_gateway).to have_received(:create) do |project|
         expect(project.type).to eq('cats')
-        expect(project.data).to eq({ cat: 'meow' })
+        expect(project.data).to eq(key: 'veryNewValue')
       end
     end
 
     it 'returns the id from the gateway' do
-      expect(response).to eq({ id: 42 })
+      expect(response).to eq(id: 42)
     end
   end
 end

--- a/spec/unit/homes_england/use_case/populate_template_spec.rb
+++ b/spec/unit/homes_england/use_case/populate_template_spec.rb
@@ -1,0 +1,235 @@
+# frozen_string_literal: true
+
+describe HomesEngland::UseCase::PopulateTemplate do
+  let(:template) {HomesEngland::Domain::Template.new(layout: {})}
+  let(:template_gateway) {double(get_template: template)}
+  let(:use_case) {described_class.new(template_gateway: template_gateway)}
+  let(:response) do
+    use_case.execute(type: type, baseline: baseline)
+  end
+  let(:baseline) {{}}
+
+  before {response}
+
+  context 'example one' do
+    let(:type) {'hif'}
+
+    it 'will find template of given type' do
+      expect(template_gateway).to have_received(:get_template).with(type: 'hif')
+    end
+
+    context 'with matching baseline and template key' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            cats: nil
+          }
+        )
+      end
+      let(:baseline) {{cats: 'meow'}}
+
+      it 'will return baseline data' do
+        expect(response).to eq(populated_data: {cats: 'meow'})
+      end
+    end
+
+    context 'with a baseline missing one top level template key' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            doggos: nil,
+            ducks: 'quack'
+          }
+        )
+      end
+      let(:baseline) {{doggos: 'woof'}}
+
+      it 'will populate template with baseline with default template values' do
+        expect(response).to eq(populated_data: {doggos: 'woof', ducks: 'quack'})
+      end
+    end
+
+    context 'with field in baseline but not in template' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            doggos: nil
+          }
+        )
+      end
+      let(:baseline) {{doggos: 'woof', ducks: 'quack'}}
+
+      it 'will populate template with baseline with default template values' do
+        expect(response).to eq(populated_data: {doggos: 'woof'})
+      end
+    end
+
+    context 'with matching baseline and template nested hash' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            doggos: nil,
+            good_animals: {
+              more_doggos: nil,
+              less_cats: nil
+            }
+          }
+        )
+      end
+      context 'with all fields in baseline' do
+        let(:baseline) do
+          {
+            doggos: 'woof',
+            good_animals: {
+              more_doggos: 'more woof',
+              less_cats: 'meow'
+            }
+          }
+        end
+
+        it 'will override template data if keys match' do
+          expect(response).to eq(populated_data: {
+            doggos: 'woof',
+            good_animals: {
+              more_doggos: 'more woof',
+              less_cats: 'meow'
+            }
+          })
+        end
+      end
+
+
+      context 'with fields missing from in baseline' do
+        let(:baseline) do
+          {
+            doggos: 'woof',
+            good_animals: {
+              less_cats: 'meow'
+            }
+          }
+        end
+
+        it 'will override template data if keys match' do
+          expect(response).to eq(populated_data: {
+            doggos: 'woof',
+            good_animals: {
+              more_doggos: nil,
+              less_cats: 'meow'
+            }
+          })
+        end
+      end
+    end
+  end
+
+  context 'example two' do
+    let(:type) {'abc'}
+
+    it 'will find template of given type' do
+      expect(template_gateway).to have_received(:get_template).with(type: 'abc')
+    end
+
+    context 'with matching baseline and template key' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            doggos: nil
+          }
+        )
+      end
+      let(:baseline) {{doggos: 'woof'}}
+
+      it 'will return baseline data' do
+        expect(response).to eq(populated_data: {doggos: 'woof'})
+      end
+    end
+
+    context 'with a baseline missing one top level template key' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            doggos: nil,
+            cows: 'moo'
+          }
+        )
+      end
+      let(:baseline) {{doggos: 'woof'}}
+
+      it 'will populate template with baseline with default template values' do
+        expect(response).to eq(populated_data: {doggos: 'woof', cows: 'moo'})
+      end
+    end
+
+    context 'with field in baseline but not in template' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            doggos: nil
+          }
+        )
+      end
+      let(:baseline) {{doggos: 'woof', cows: 'moo'}}
+
+      it 'will populate template with baseline with default template values' do
+        expect(response).to eq(populated_data: {doggos: 'woof'})
+      end
+    end
+
+    context 'with matching baseline and template nested hash' do
+      let(:template) do
+        HomesEngland::Domain::Template.new(
+          layout: {
+            cows: nil,
+            more_animals: {
+              cats: nil,
+              dogs: nil
+            }
+          }
+        )
+      end
+      context 'with all fields in baseline' do
+        let(:baseline) do
+          {
+            cows: 'moo',
+            more_animals: {
+              cats: 'meow',
+              dogs: 'woof'
+            }
+          }
+        end
+
+        it 'will override template data if keys match' do
+          expect(response).to eq(populated_data: {
+            cows: 'moo',
+            more_animals: {
+              cats: 'meow',
+              dogs: 'woof'
+            }
+          })
+        end
+      end
+
+
+      context 'with fields missing from in baseline' do
+        let(:baseline) do
+          {
+            cows: 'moo',
+            more_animals: {
+              cats: 'meow'
+            }
+          }
+        end
+
+        it 'will override template data if keys match' do
+          expect(response).to eq(populated_data: {
+            cows: 'moo',
+            more_animals: {
+              cats: 'meow',
+              dogs: nil
+            }
+          })
+        end
+      end
+    end
+  end
+end

--- a/spec/web_routes/finding_project_spec.rb
+++ b/spec/web_routes/finding_project_spec.rb
@@ -1,89 +1,85 @@
+# frozen_string_literal: true
+
 require 'rspec'
 require_relative 'delivery_mechanism_spec_helper'
 
 describe 'Finding a project' do
-  let(:project_data) do
-    {
-      type: 'hif',
-      baselineData: {
-        cats: 'meow',
-        dogs: 'woof'
-      }
-    }
+  before do
+    stub_const(
+      'HomesEngland::UseCase::FindProject',
+      double(new: find_project_spy)
+    )
+
+    get "/project/find?id=#{project_id}"
   end
 
-  context 'with an invalid id' do
+  context 'with an non existant id' do
+    let(:project_id) { 42 }
     let(:find_project_spy) { spy(execute: nil) }
 
-    context 'example one' do
-      let(:id) { 42 }
-
-      before do
-        stub_const(
-          'HomesEngland::UseCase::FindProject',
-          double(new: find_project_spy)
-        )
-        get '/project/find'
-        { id: 99 }
-      end
-
-      it 'should should return 404' do
-        expect(last_response.status).to eq(404)
-      end
-    end
-
-    context 'example two' do
-      let(:id) { nil }
-
-      before do
-        stub_const(
-          'HomesEngland::UseCase::FindProject',
-          double(new: find_project_spy)
-        )
-        get '/project/find'
-        { id: 99 }
-      end
-
-      it 'should should return 404' do
-        expect(last_response.status).to eq(404)
-      end
-    end
-
-    context 'example one' do
-      let(:id) { 'Cats' }
-
-      before do
-        stub_const(
-          'HomesEngland::UseCase::FindProject',
-          double(new: find_project_spy)
-        )
-        get '/project/find'
-        { id: 99 }
-      end
-
-      it 'should should return 404' do
-        expect(last_response.status).to eq(404)
-      end
+    it 'should should return 404' do
+      expect(last_response.status).to eq(404)
     end
   end
 
   context 'with an valid id' do
-    before do
-      post '/project/create',
-           project_data.to_json
-      response_body = JSON.parse(last_response.body)
-      get "/project/find?id=#{response_body['projectId']['id']}"
+    context 'example one' do
+      let(:project_id) { 42 }
+      let(:project) do
+        HomesEngland::Domain::Project.new.tap do |p|
+          p.type = 'hif'
+          p.data = { cats_go: 'meow', dogs_go: 'woof' }
+        end
+      end
+
+      let(:find_project_spy) { spy(execute: project) }
+
+      it 'should find the project with the given id' do
+        expect(find_project_spy).to have_received(:execute).with(id: 42)
+      end
+
+      it 'should should return 200' do
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'should should have project in body with camel case' do
+        response_body = JSON.parse(last_response.body)
+        expect(response_body['type']).to eq('hif')
+        expect(response_body['data']['catsGo']).to eq('meow')
+        expect(response_body['data']['dogsGo']).to eq('woof')
+      end
     end
 
-    it 'should should return 200' do
-      expect(last_response.status).to eq(200)
-    end
+    context 'example two' do
+      let(:project_id) { 41 }
+      let(:project) do
+        HomesEngland::Domain::Project.new.tap do |p|
+          p.type = 'abc'
+          p.data = {
+            animal_noises: [
+              { ducks_go: 'quack' },
+              { cows_go: 'moo' }
+            ]
+          }
+        end
+      end
 
-    it 'should should have project in body' do
-      response_body = JSON.parse(last_response.body)
-      expect(response_body['type']).to eq('hif')
-      expect(response_body['data']['cats']).to eq('meow')
-      expect(response_body['data']['dogs']).to eq('woof')
+      let(:find_project_spy) { spy(execute: project) }
+
+      it 'should find the project with the given id' do
+        expect(find_project_spy).to have_received(:execute).with(id: 41)
+      end
+
+      it 'should should return 200' do
+        expect(last_response.status).to eq(200)
+      end
+
+      it 'should should have project in body with camel case' do
+        response_body = JSON.parse(last_response.body)
+        expect(response_body['type']).to eq('abc')
+        expect(response_body['data']['animalNoises'][0]['ducksGo']).to eq('quack')
+        expect(response_body['data']['animalNoises'][1]['cowsGo']).to eq('moo')
+      end
     end
   end
 end


### PR DESCRIPTION
**WHAT**
Create project populates template data with baseline data.
Added populate template use case which will create a Project data structure by merging baseline data with template data.
Cleaned up some tests whilst logic was added.

**WHY**
Previously the create project cloned the baseline data. We need the baseline data to populate an existing template. 