### PR TITLE
GetReturns can now be accessed via /project/:id/returns

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -63,6 +63,12 @@ module DeliveryMechanism
       end
     end
 
+    get '/project/:id/returns' do
+      returns = @use_case_factory.get_use_case(:get_returns).execute(project_id: params['id'].to_i)
+      response.status = returns.empty? ? 404 : 200
+      response.body = returns.to_json
+    end
+
     get '/project/find' do
       return 404 if params['id'].nil?
 

--- a/lib/local_authority/use_case/get_returns.rb
+++ b/lib/local_authority/use_case/get_returns.rb
@@ -4,12 +4,15 @@ class LocalAuthority::UseCase::GetReturns
   end
 
   def execute(project_id:)
-    @return_gateway.get_returns(project_id: project_id).map do |r|
-      {
-        id: r.id,
-        project_id: r.project_id,
-        data: r.data
-      }
-    end
+    {
+      returns:
+        @return_gateway.get_returns(project_id: project_id).map do |r|
+        {
+          id: r.id,
+          project_id: r.project_id,
+          data: r.data
+        }
+      end
+    }
   end
 end

--- a/lib/local_authority/use_case/get_returns.rb
+++ b/lib/local_authority/use_case/get_returns.rb
@@ -1,4 +1,4 @@
-class HomesEngland::UseCase::GetReturns
+class LocalAuthority::UseCase::GetReturns
   def initialize(return_gateway:)
     @return_gateway = return_gateway
   end

--- a/lib/local_authority/use_cases.rb
+++ b/lib/local_authority/use_cases.rb
@@ -34,9 +34,9 @@ class LocalAuthority::UseCases
         return_gateway: builder.get_use_case(:return_gateway)
       )
     end
-    
+
     builder.define_use_case :get_returns do
-      HomesEngland::UseCase::GetReturns.new(
+      LocalAuthority::UseCase::GetReturns.new(
         return_gateway: builder.get_use_case(:return_gateway)
       )
     end

--- a/spec/acceptance/local_authority/get_returns_spec.rb
+++ b/spec/acceptance/local_authority/get_returns_spec.rb
@@ -51,6 +51,7 @@ describe 'Getting multiple returns' do
 
     ]
   end
+
   it 'can get multiple returns by project id from a gateway' do
     get_use_case(:create_return).execute(project_id: 1, data:
       {
@@ -105,6 +106,6 @@ describe 'Getting multiple returns' do
         }
       })
 
-    expect(get_use_case(:get_returns).execute(project_id: 1)).to eq(returns_for_project_1)
+    expect(get_use_case(:get_returns).execute(project_id: 1)[:returns]).to match_array(returns_for_project_1)
   end
 end

--- a/spec/unit/local_authority/use_case/get_returns_spec.rb
+++ b/spec/unit/local_authority/use_case/get_returns_spec.rb
@@ -1,6 +1,6 @@
 require 'rspec'
 
-describe HomesEngland::UseCase::GetReturns do
+describe LocalAuthority::UseCase::GetReturns do
   let(:all_returns) { [] }
   let(:all_return_objects) { [] }
   let(:return_gateway) { spy(get_returns: all_return_objects) }

--- a/spec/unit/local_authority/use_case/get_returns_spec.rb
+++ b/spec/unit/local_authority/use_case/get_returns_spec.rb
@@ -34,7 +34,7 @@ describe LocalAuthority::UseCase::GetReturns do
     end
 
     it 'can get a single return as an item in an array' do
-      expect(get_returns.execute(project_id: 1)).to match_array(all_returns)
+      expect(get_returns.execute(project_id: 1)[:returns]).to match_array(all_returns)
     end
   end
 
@@ -70,7 +70,7 @@ describe LocalAuthority::UseCase::GetReturns do
     end
 
     it 'can get multiple items as an array' do
-      expect(get_returns.execute(project_id: 1)).to match_array(all_returns)
+      expect(get_returns.execute(project_id: 1)[:returns]).to match_array(all_returns)
     end
   end
 end

--- a/spec/web_routes/get_returns_spec.rb
+++ b/spec/web_routes/get_returns_spec.rb
@@ -20,6 +20,10 @@ describe 'Getting return history' do
       get '/project/1/returns'
     end
 
+    it 'passes the correct id to the use case' do
+      expect(get_returns_spy).to have_received(:execute).with(project_id: 1)
+    end
+
     it 'should respond with 200 for a project that exists' do
       expect(last_response.status).to eq(200)
     end
@@ -44,6 +48,10 @@ describe 'Getting return history' do
 
     before do
       get '/project/3/returns'
+    end
+
+    it 'passes the correct id to the use case' do
+      expect(get_returns_spy).to have_received(:execute).with(project_id: 3)
     end
 
     it 'should respond with 200 for a project that exists' do

--- a/spec/web_routes/get_returns_spec.rb
+++ b/spec/web_routes/get_returns_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative 'delivery_mechanism_spec_helper'
+
+describe 'Getting return history' do
+  let(:get_returns_spy) { spy(execute: returned_hashes) }
+
+  before do
+    stub_const(
+      'LocalAuthority::UseCase::GetReturns',
+      double(new: get_returns_spy)
+    )
+  end
+
+  context 'example 1' do
+    let(:returned_hashes) { [{ project_id: 1, data: { cats: 'Meow' } }] }
+
+    before do
+      get '/project/1/returns'
+    end
+
+    it 'should respond with 200 for a project that exists' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'should respond with an accurate array of hashes' do
+      response = Common::DeepSymbolizeKeys.to_symbolized_hash(
+        JSON.parse(last_response.body)
+      )
+      expect(response).to match_array(
+        [
+          {
+            project_id: 1,
+            data: { cats: 'Meow' }
+          }
+        ]
+      )
+    end
+  end
+
+  context 'example 2' do
+    let(:returned_hashes) { [{ project_id: 3, data: { cows: 'Moo' } }] }
+
+    before do
+      get '/project/3/returns'
+    end
+
+    it 'should respond with 200 for a project that exists' do
+      expect(last_response.status).to eq(200)
+    end
+
+    it 'should respond with an accurate array of hashes' do
+      response = Common::DeepSymbolizeKeys.to_symbolized_hash(
+        JSON.parse(last_response.body)
+      )
+      expect(response).to match_array(
+        [
+          {
+            project_id: 3,
+            data: { cows: 'Moo' }
+          }
+        ]
+      )
+    end
+  end
+
+  context 'without any found hashes' do
+    let(:returned_hashes) { [] }
+
+    before do
+      get '/project/4096/returns'
+    end
+
+    it 'should respond with 404 for a project that does not exist' do
+      expect(last_response.status).to eq(404)
+    end
+
+    it 'should return an empty array' do
+      expect(JSON.parse(last_response.body)).to match_array([])
+    end
+  end
+end


### PR DESCRIPTION
Also addresses some mild errors in my last pull