### PR TITLE
Change projectSummary to summary

### DIFF
--- a/lib/homes_england/gateway/in_memory_template.rb
+++ b/lib/homes_england/gateway/in_memory_template.rb
@@ -9,7 +9,7 @@ class HomesEngland::Gateway::InMemoryTemplate
       title: 'HIF Project',
       type: 'object',
       properties: {
-        projectSummary: hif_summary,
+        summary: hif_summary,
         infrastructures: hif_infrastructures,
         financial: hif_finances,
         s151: hif_s151,


### PR DESCRIPTION
WHAT - Changes the projectSummary key in the project schema to summary

WHY 
- Redundant naming
- Frontend will soon depend on a "Summary" key existing