### PR TITLE
Add gov notify simulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ docker-stop:
 	docker-compose stop
 
 serve: docker-stop docker-build
-	docker-compose run --rm --service-ports web
+	docker-compose up 
 
 shell: docker-build
 	docker-compose run --rm web ash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,21 @@ services:
       - "4567:4567"
     links:
       - db
+      - notify_simulator
     command: "bundle exec rerun --background 'ash bin/serve.sh'"
     privileged: true
     environment:
       DATABASE_URL: 'postgres://postgres:super-secret@db/monitor_api'
       PROJECT_FILE_PATH: 'projects.json'
+      GOV_NOTIFY_API_URL: 'http://notify_simulator'
       EMAIL_WHITELIST: "${EMAIL_WHITELIST}"
       GOV_NOTIFY_API_KEY: "${GOV_NOTIFY_API_KEY}"
+
+  notify_simulator:
+    build: .
+    volumes:
+      - ./:/app
+    ports:
+      - "7654:4567"
+    privileged: true
+    command: "bundle exec rerun --background -- ruby ./simulators/notify.rb -o 0.0.0.0 -p 80"

--- a/lib/local_authority/gateway/gov_email_notification_gateway.rb
+++ b/lib/local_authority/gateway/gov_email_notification_gateway.rb
@@ -3,7 +3,7 @@
 require 'notifications/client'
 class LocalAuthority::Gateway::GovEmailNotificationGateway
   def initialize
-    @client = Notifications::Client.new(ENV.fetch('GOV_NOTIFY_API_KEY'))
+    @client = Notifications::Client.new(ENV.fetch('GOV_NOTIFY_API_KEY'), base_url=ENV['GOV_NOTIFY_API_URL'])
     @default_template = 'b8fc89b6-79c6-491f-9872-60e110130e4a'
   end
 

--- a/spec/unit/local_authority/gateway/gov_email_notification_gateway_spec.rb
+++ b/spec/unit/local_authority/gateway/gov_email_notification_gateway_spec.rb
@@ -5,22 +5,30 @@ describe LocalAuthority::Gateway::GovEmailNotificationGateway do
     spy(send_email: {})
   end
 
+  let(:notifications_client_spy) do
+    spy(new: send_mail_spy, meow: 'cat')
+  end
+
   before do
     stub_const(
       'Notifications::Client',
-      double(new: send_mail_spy)
-    )
-
-    stub_const(
-      'ENV',
-      double(fetch: nil)
+      notifications_client_spy
     )
   end
 
   context 'example 1' do
+    before do
+      ENV['GOV_NOTIFY_API_KEY'] = 'superSecret'
+      ENV['GOV_NOTIFY_API_URL'] = 'meow.com'
+      described_class.new.send_notification(to: 'cat@cathouse.com', url: 'http://cats.com', access_token: 'CatAccess')
+    end
+
     context 'given email address and url' do
+      it 'passes the API key and url to the notifications client' do
+        expect(notifications_client_spy).to have_received(:new).with('superSecret', 'meow.com')
+      end
+
       it 'will run send_email with address and url within personalisation hash' do
-        described_class.new.send_notification(to: 'cat@cathouse.com', url: 'http://cats.com', access_token: 'CatAccess')
         expect(send_mail_spy).to have_received(:send_email) do |args|
           expect(args[:email_address]).to eq('cat@cathouse.com')
           expect(args[:personalisation]).to eq(access_url: 'http://cats.com' + '/?token=CatAccess')
@@ -30,9 +38,18 @@ describe LocalAuthority::Gateway::GovEmailNotificationGateway do
   end
 
   context 'example 2' do
+    before do
+      ENV['GOV_NOTIFY_API_KEY'] = 'megaSecure'
+      ENV['GOV_NOTIFY_API_URL'] = 'dog.woof'
+      described_class.new.send_notification(to: 'dog@doghouse.com', url: 'http://dogs.com', access_token: 'DogAccess')
+    end
+
     context 'given email address and url' do
+      it 'passes the API key and url to the notifications client' do
+        expect(notifications_client_spy).to have_received(:new).with('megaSecure', 'dog.woof')
+      end
+
       it 'will run send_email with address and url within personalisation hash' do
-        described_class.new.send_notification(to: 'dog@doghouse.com', url: 'http://dogs.com', access_token: 'DogAccess')
         expect(send_mail_spy).to have_received(:send_email) do |args|
           expect(args[:email_address]).to eq('dog@doghouse.com')
           expect(args[:personalisation]).to eq(access_url: 'http://dogs.com' + '/?token=DogAccess')


### PR DESCRIPTION
WHAT
- Simulates gov notify on local dev
- Puts the token url in the console rather than sending emails

WHY

- Testing locally was painful and would require emails to be sent via gov notify
- We would expend our email allowance, and not be able to run it locally