### PR TITLE
Returns from returns

### DIFF
--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -1299,7 +1299,8 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   hifSpendLastReturn: {
                                     type: 'integer',
                                     readonly: true,
-                                    title: 'TO BE CALCULATED - Current HIF spend since last return'
+                                    title: 'TO BE CALCULATED - Current HIF spend since last return',
+                                    sourceKey: [:return_data, :funding, :fundingPackages, :fundingPackage, :overview, :hifSpendSinceLastReturn, :hifSpendCurrentReturn]
                                   },
                                   hifSpendVariance: {
                                     type: 'integer',

--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -21,12 +21,12 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                   type: 'string',
                   # This is marked as a dropdown but also from baseline?
                   title: 'Type',
-                  baselineKey: [:infrastructures, :type]
+                  sourceKey: [:baseline_data, :infrastructures, :type]
                 },
                 description: {
                   type: 'string',
                   title: 'Description',
-                  baselineKey: [:infrastructures, :description]
+                  sourceKey: [:baseline_data, :infrastructures, :description]
                 },
                 planning: {
                   type: 'object',
@@ -37,7 +37,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                     baselineOutlinePlanningPermissionGranted: {
                       type: 'boolean',
                       title: 'Outline Planning Permission granted',
-                      baselineKey: [:infrastructures, :outlinePlanningStatus, :granted]
+                      sourceKey: [:baseline_data, :infrastructures, :outlinePlanningStatus, :granted]
                     },
                     planningNotGranted: {
                       type: 'object',
@@ -47,7 +47,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         baselineSummaryOfCriticalPath: {
                           type: 'string',
                           title: 'Summary Of Outline Planning Permission Critical Path',
-                          baselineKey: [:infrastructures, :outlinePlanningStatus, :summaryOfCriticalPath]
+                          sourceKey: [:baseline_data, :infrastructures, :outlinePlanningStatus, :summaryOfCriticalPath]
                         },
                         fieldOne: {
                           type: 'object',
@@ -63,7 +63,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   type: 'string',
                                   format: 'date',
                                   title: 'Full Planning Permission submitted date',
-                                  baselineKey: [:infrastructures, :fullPlanningStatus, :targetSubmission]
+                                  sourceKey: [:baseline_data, :infrastructures, :fullPlanningStatus, :targetSubmission]
                                 },
                                 # Full planning granted date
                                 # fullPlanningStatus.targetGranted
@@ -71,7 +71,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   type: 'string',
                                   format: 'date',
                                   title: 'Full Planning Permission granted date',
-                                  baselineKey: [:infrastructures, :fullPlanningStatus, :targetGranted]
+                                  sourceKey: [:baseline_data, :infrastructures, :fullPlanningStatus, :targetGranted]
                                 }
                               }
                             },
@@ -164,13 +164,13 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                             fullPlanningPermissionGranted: {
                               type: 'boolean',
                               title: 'Full Planning Permission granted',
-                              baselineKey: [:infrastructures, :fullPlanningStatus, :granted]
+                              sourceKey: [:baseline_data, :infrastructures, :fullPlanningStatus, :granted]
                             },
                             # from fullPlanningStatus.summaryOfCriticalPath
                             fullPlanningPermissionSummaryOfCriticalPath: {
                               type: 'string',
                               title: 'Summary Of Full Planning Permission Critical Path',
-                              baselineKey: [:infrastructures, :fullPlanningStatus, :summaryOfCriticalPath]
+                              sourceKey: [:baseline_data, :infrastructures, :fullPlanningStatus, :summaryOfCriticalPath]
                             }
                           }
                         },
@@ -188,7 +188,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   type: 'string',
                                   format: 'date',
                                   title: 'Full Planning Permission submitted date',
-                                  baselineKey: [:infrastructures, :fullPlanningStatus, :targetSubmission]
+                                  sourceKey: [:baseline_data, :infrastructures, :fullPlanningStatus, :targetSubmission]
                                 },
                                 # Full planning granted date
                                 # fullPlanningStatus.targetGranted
@@ -196,7 +196,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   type: 'string',
                                   format: 'date',
                                   title: 'Full Planning Permission granted date',
-                                  baselineKey: [:infrastructures, :fullPlanningStatus, :targetGranted]
+                                  sourceKey: [:baseline_data, :infrastructures, :fullPlanningStatus, :targetGranted]
                                 }
                               }
                             },
@@ -291,13 +291,13 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         s106Requirement: {
                           type: 'boolean',
                           title: 'S016 Requirement',
-                          baselineKey: [:infrastructures, :s106, :requirement]
+                          sourceKey: [:baseline_data, :infrastructures, :s106, :requirement]
                         },
                         # from s106.summaryOfRequirement
                         s106SummaryOfRequirement: {
                           type: 'string',
                           title: 'Summary of S016 Requirement ',
-                          baselineKey: [:infrastructures, :s106, :summaryOfRequirement]
+                          sourceKey: [:baseline_data, :infrastructures, :s106, :summaryOfRequirement]
                         },
                         # from statutoryConsents.anyConsents
                         statutoryConsents: {
@@ -307,7 +307,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                             anyStatutoryConsents: {
                               type: 'boolean',
                               title: 'Statutory consents to be met?',
-                              baselineKey: [:infrastructures, :statutoryConsents, :anyConsents]
+                              sourceKey: [:baseline_data, :infrastructures, :statutoryConsents, :anyConsents]
                             }
                           }
                         }
@@ -443,7 +443,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                     laHasControlOfSite: {
                       type: 'boolean',
                       title: 'LA Control of site(s) (related to infrastructure)? ',
-                      baselineKey: [:infrastructures, :landOwnership, :landAcquisitionRequired]
+                      sourceKey: [:baseline_data, :infrastructures, :landOwnership, :landAcquisitionRequired]
                     },
                     laDoesNotControlSite: {
                       type: 'object',
@@ -453,13 +453,13 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         whoOwnsSite: {
                           type: 'string',
                           title: 'Who owns site?',
-                          baselineKey: [:infrastructures, :landOwnership, :ownershipOfLandOtherThanLA]
+                          sourceKey: [:baseline_data, :infrastructures, :landOwnership, :ownershipOfLandOtherThanLA]
                         },
                         # from landOwnership.landAcquisitionRequired
                         landAquisitionRequired: {
                           type: 'boolean',
                           title: 'Land acquisition required (related to infrastructure)?',
-                          baselineKey: [:infrastructures, :landOwnership, :landAcquisitionRequired]
+                          sourceKey: [:baseline_data, :infrastructures, :landOwnership, :landAcquisitionRequired]
                         }
                       }
                     },
@@ -471,19 +471,19 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         howManySitesToAquire: {
                           type: 'integer',
                           title: 'Number of Sites to aquire?',
-                          baselineKey: [:infrastructures, :landOwnership, :howManySitesToAcquire]
+                          sourceKey: [:baseline_data, :infrastructures, :landOwnership, :howManySitesToAcquire]
                         },
                         # from landOwnership.toBeAquiredBy
                         toBeAquiredBy: {
                           type: 'string',
                           title: 'Acquired by LA or Developer?',
-                          baselineKey: [:infrastructures, :landOwnership, :toBeAcquiredBy]
+                          sourceKey: [:baseline_data, :infrastructures, :landOwnership, :toBeAcquiredBy]
                         },
                         # from landOwnership.summaryOfCriticalPath
                         summaryOfAcquisitionRequired: {
                           type: 'string',
                           title: 'Summary of acquisition required',
-                          baselineKey: [:infrastructures, :landOwnership, :summaryOfCriticalPath]
+                          sourceKey: [:baseline_data, :infrastructures, :landOwnership, :summaryOfCriticalPath]
                         },
                         allLandAssemblyAchieved: {
                           type: 'object',
@@ -494,7 +494,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                               type: 'string',
                               format: 'date',
                               title: 'Baseline Completion',
-                              baselineKey: [:infrastructures, :landOwnership, :targetDateToAcquire]
+                              sourceKey: [:baseline_data, :infrastructures, :landOwnership, :targetDateToAcquire]
                             },
                             # To be calculated
                             landAssemblyVarianceAgainstLastReturn: {
@@ -558,7 +558,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                     contractorProcured: {
                       type: 'boolean',
                       title: 'Infrastructure contractor procured?',
-                      baselineKey: [:infrastructures, :landOwnership, :procurement, :contractorProcured]
+                      sourceKey: [:baseline_data, :infrastructures, :landOwnership, :procurement, :contractorProcured]
                     },
                     infrastructureNotProcured: {
                       type: 'object',
@@ -573,7 +573,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                               type: 'string',
                               format: 'date',
                               title: 'Target date of procuring',
-                              baselineKey: [:infrastructures, :landOwnership,  :procurement, :targetDateToAquire]
+                              sourceKey: [:baseline_data, :infrastructures, :landOwnership,  :procurement, :targetDateToAquire]
                             },
                             procurementVarianceAgainstLastReturn: {
                               type: 'string',
@@ -628,7 +628,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                           },
                           # from procurement.summaryOfCriticalPath
                           summaryOfCriticalPath: {
-                            baselineKey: [:infrastructures, :landOwnership,:procurement, :summaryOfCriticalPath],
+                            sourceKey: [:baseline_data, :infrastructures, :landOwnership,:procurement, :summaryOfCriticalPath],
                             type: 'string',
                             title: 'Summary of Critical Procurement Path'
                           }
@@ -641,7 +641,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                       properties: {
                         # from procurement.nameOfContractor
                         nameOfContractor: {
-                          baselineKey: [:infrastructures, :landOwnership,:procurement, :nameOfContractor],
+                          sourceKey: [:baseline_data, :infrastructures, :landOwnership,:procurement, :nameOfContractor],
                           type: 'string',
                           title: 'Name of Contractor'
                         }
@@ -661,14 +661,14 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         properties: {
                           # from milestones.target
                           milestoneBaselineCompletion: {
-                            baselineKey: [:infrastructures, :milestones, :target],
+                            sourceKey: [:baseline_data, :infrastructures, :milestones, :target],
                             type: 'string',
                             format: 'date',
                             title: 'Baseline Completion '
                           },
                           # from milestones.summaryOfCriticalPath
                           milestoneSummaryOfCriticalPath: {
-                            baselineKey: [:infrastructures, :milestones, :summaryOfCriticalPath],
+                            sourceKey: [:baseline_data, :infrastructures, :milestones, :summaryOfCriticalPath],
                             type: 'string',
                             title: 'Summary of Baseline Critical Path'
                           },
@@ -727,7 +727,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                       properties: {
                         milestoneExpectedInfrastructureStartBaseline: {
                           # from milestones.expectedInfrastructureStart
-                          baselineKey: [:infrastructures, :expectedInfrastructureStart, :targetDateOfAchievingStart],
+                          sourceKey: [:baseline_data, :infrastructures, :expectedInfrastructureStart, :targetDateOfAchievingStart],
                           type: 'string',
                           title: 'Baseline Start on site'
                         },
@@ -781,7 +781,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                       properties: {
                         milestoneExpectedInfrastructureCompletionBaseline: {
                           # from milestones.expectedInfrastructureCompletion
-                          baselineKey: [:infrastructures, :expectedInfrastructureCompletion, :targetDateOfAchievingCompletion],
+                          sourceKey: [:baseline_data, :infrastructures, :expectedInfrastructureCompletion, :targetDateOfAchievingCompletion],
                           type: 'string',
                           title: 'Baseline Completion'
                         },
@@ -851,19 +851,19 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                 properties: {
                                   # from risksToAchievingTimescales.descriptionOfRisk
                                   riskBaselineRisk: {
-                                  baselineKey: [:infrastructures, :risksToAchievingTimescales, :descriptionOfRisk],
+                                  sourceKey: [:baseline_data, :infrastructures, :risksToAchievingTimescales, :descriptionOfRisk],
                                     type: 'string',
                                     title: 'Description Of Risk'
                                   },
                                   # from risksToAchievingTimescales.impactOfRisk
                                   riskBaselineImpact: {
-                                    baselineKey: [:infrastructures, :risksToAchievingTimescales, :impactOfRisk],
+                                    sourceKey: [:baseline_data, :infrastructures, :risksToAchievingTimescales, :impactOfRisk],
                                     type: 'string',
                                     title: 'Impact'
                                   },
                                   # from risksToAchievingTimescales.likelihoodOfRisk
                                   riskBaselineLikelihood: {
-                                    baselineKey: [:infrastructures, :risksToAchievingTimescales, :likelihoodOfRisk],
+                                    sourceKey: [:baseline_data, :infrastructures, :risksToAchievingTimescales, :likelihoodOfRisk],
                                     type: 'string',
                                     title: 'Likelihood'
                                   },
@@ -873,7 +873,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   },
                                   # from risksToAchievingTimescales.mitigationOfRisk
                                   riskBaselineMitigationsInPlace: {
-                                    baselineKey: [:infrastructures, :risksToAchievingTimescales, :mitigationOfRisk],
+                                    sourceKey: [:baseline_data, :infrastructures, :risksToAchievingTimescales, :mitigationOfRisk],
                                     type: 'string',
                                     title: 'Mitigation in place'
                                   },
@@ -1067,7 +1067,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         type: 'string',
                         # from items.instalments.baselineInstalments.baselineInstalmentYear
                         title: 'Funding Year',
-                        baselineKey: [:financial, :instalments, :baselineInstalments, :baselineInstalmentYear]
+                        sourceKey: [:baseline_data, :financial, :instalments, :baselineInstalments, :baselineInstalmentYear]
                       },
                       forecast: {
                         type: 'object',
@@ -1077,31 +1077,31 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                             type: 'string',
                             # from items.instalments.baselineInstalments.baselineInstalmentQ1
                             title: 'Forecast Q1',
-                            baselineKey: [:financial, :instalments, :baselineInstalments, :baselineInstalmentQ1]
+                            sourceKey: [:baseline_data, :financial, :instalments, :baselineInstalments, :baselineInstalmentQ1]
                           },
                           forecastQ2: {
                             type: 'string',
                             # from items.instalments.baselineInstalments.baselineInstalmentQ2
                             title: 'Forecast Q2',
-                            baselineKey: [:financial, :instalments, :baselineInstalments, :baselineInstalmentQ2]
+                            sourceKey: [:baseline_data, :financial, :instalments, :baselineInstalments, :baselineInstalmentQ2]
                           },
                           forecastQ3: {
                             type: 'string',
                             # from items.instalments.baselineInstalments.baselineInstalmentQ3
                             title: 'Forecast Q3',
-                            baselineKey: [:financial, :instalments, :baselineInstalments, :baselineInstalmentQ3]
+                            sourceKey: [:baseline_data, :financial, :instalments, :baselineInstalments, :baselineInstalmentQ3]
                           },
                           forecastQ4: {
                             type: 'string',
                             # from items.instalments.baselineInstalments.baselineInstalmentQ4
                             title: 'Forecast Q4',
-                            baselineKey: [:financial, :instalments, :baselineInstalments, :baselineInstalmentQ4]
+                            sourceKey: [:baseline_data, :financial, :instalments, :baselineInstalments, :baselineInstalmentQ4]
                           },
                           forecastTotal: {
                             type: 'string',
                             # from items.instalments.baselineInstalments.baselineInstalmentTotal
                             title: 'Forecast Total',
-                            baselineKey: [:financial, :instalments, :baselineInstalments, :baselineInstalmentTotal]
+                            sourceKey: [:baseline_data, :financial, :instalments, :baselineInstalments, :baselineInstalmentTotal]
                           }
                         },
                       },
@@ -1245,7 +1245,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                 properties: {
                                   # finances.costs.costOfInfrastructure
                                   baselineCost: {
-                                    baselineKey: [:financial, :costs, :costOfInfrastructure],
+                                    sourceKey: [:baseline_data, :financial, :costs, :costOfInfrastructure],
                                     type: 'integer',
                                     title: 'Cost of Infrastructure'
                                   },
@@ -1321,7 +1321,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                             properties: {
                               # from costs.fundingstack.totallyFundedThroughHIF
                               totallyFundedThroughHIF: {
-                                baselineKey: [:financial, :costs, :fundingStack, :totallyFundedThroughHIF],
+                                sourceKey: [:baseline_data, :financial, :costs, :fundingStack, :totallyFundedThroughHIF],
                                 type: 'boolean',
                                 title: 'Totally funded through HIF?'
                               },
@@ -1332,7 +1332,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                 properties: {
                                   # from costs.fundingstack.descriptionOfFundingStack
                                   descriptionOfFundingStack: {
-                                    baselineKey: [:financial, :costs, :fundingStack, :descriptionOfFundingStack],
+                                    sourceKey: [:baseline_data, :financial, :costs, :fundingStack, :descriptionOfFundingStack],
                                     type: 'string',
                                     title: 'Description of Funding Stack'
                                   },
@@ -1351,7 +1351,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                     properties: {
                                       # from costs.fundingStack.totalPublic.
                                       publicTotalBaselineAmount: {
-                                        baselineKey: [:financial, :costs, :fundingStack, :totalPublic],
+                                        sourceKey: [:baseline_data, :financial, :costs, :fundingStack, :totalPublic],
                                         type: 'integer',
                                         title: 'Total Public Baseline Amount'
                                       },
@@ -1410,7 +1410,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                     properties: {
                                       # from costs.fundingStack.totalPrivate
                                       privateTotalBaselineAmount: {
-                                        baselineKey: [:financial, :costs, :fundingStack, :totalPrivate],
+                                        sourceKey: [:baseline_data, :financial, :costs, :fundingStack, :totalPrivate],
                                         type: 'integer',
                                         title: 'Total Private Baseline Amount'
                                       },
@@ -1478,7 +1478,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                   properties: {
                     # from costs.recovery.aimToRecover
                     aimToRecover: {
-                      baselineKey: [:financial, :recovery, :aimToRecover],
+                      sourceKey: [:baseline_data, :financial, :recovery, :aimToRecover],
                       type: 'boolean',
                       title: 'Aim to recover any funding?'
                     },

--- a/lib/local_authority/use_case/create_return.rb
+++ b/lib/local_authority/use_case/create_return.rb
@@ -8,7 +8,6 @@ class LocalAuthority::UseCase::CreateReturn
     created_return_id = create_return_for_project(project_id)
     create_return_update(created_return_id, data)
 
-
     { id: created_return_id }
   end
 

--- a/lib/local_authority/use_case/find_path_data.rb
+++ b/lib/local_authority/use_case/find_path_data.rb
@@ -1,4 +1,4 @@
-class LocalAuthority::UseCase::FindBaselinePath
+class LocalAuthority::UseCase::FindPathData
   def execute(baseline_data, path)
     { found: search_hash(baseline_data, path) }
   end

--- a/lib/local_authority/use_case/find_path_data.rb
+++ b/lib/local_authority/use_case/find_path_data.rb
@@ -1,6 +1,11 @@
 class LocalAuthority::UseCase::FindPathData
   def execute(baseline_data, path)
-    { found: search_hash(baseline_data, path) }
+    found = search_hash(baseline_data, path)
+    if !(found.nil? || found.empty?)
+      { found: found }
+    else
+      {}
+    end
   end
 
   private

--- a/lib/local_authority/use_case/get_base_return.rb
+++ b/lib/local_authority/use_case/get_base_return.rb
@@ -34,6 +34,7 @@ class LocalAuthority::UseCase::GetBaseReturn
         baseline_data: project.data,
         return_data: return_data
       )[:populated_data]
+
     else
       @populate_return_template.execute(
         type: project.type,

--- a/lib/local_authority/use_case/get_base_return.rb
+++ b/lib/local_authority/use_case/get_base_return.rb
@@ -9,7 +9,7 @@ class LocalAuthority::UseCase::GetBaseReturn
   end
 
   def execute(project_id:)
-    return_data = @get_returns.execute(project_id: project_id)&.[](:returns)&.[](-1)&.[](:updates)&.[](-1)
+    return_data = @get_returns.execute(project_id: project_id).dig(:returns, -1, :updates, -1)
     project = @project_gateway.find_by(id: project_id)
     schema = @return_gateway.find_by(type: project.type)
     if return_data.nil?

--- a/lib/local_authority/use_case/get_base_return.rb
+++ b/lib/local_authority/use_case/get_base_return.rb
@@ -1,17 +1,24 @@
 # frozen_string_literal: true
 
 class LocalAuthority::UseCase::GetBaseReturn
-  def initialize(return_gateway:, project_gateway:, populate_return_template:)
+  def initialize(return_gateway:, project_gateway:, populate_return_template:, get_returns:)
     @return_gateway = return_gateway
     @project_gateway = project_gateway
     @populate_return_template = populate_return_template
+    @get_returns = get_returns
   end
 
   def execute(project_id:)
+    return_data = @get_returns.execute(project_id: project_id)&.[](:returns)&.[](-1)&.[](:updates)&.[](-1)
     project = @project_gateway.find_by(id: project_id)
     schema = @return_gateway.find_by(type: project.type)
-    data = @populate_return_template.execute(type: project.type,
-      baseline_data: project.data)[:populated_data]
+    if return_data.nil?
+      data = @populate_return_template.execute(type: project.type,
+        baseline_data: project.data)[:populated_data]
+    else
+      data = @populate_return_template.execute(type: project.type,
+        baseline_data: project.data, return_data: return_data)[:populated_data]
+    end
 
     { base_return: { id: project_id, data: data, schema: schema.schema } }
   end

--- a/lib/local_authority/use_case/get_base_return.rb
+++ b/lib/local_authority/use_case/get_base_return.rb
@@ -9,17 +9,36 @@ class LocalAuthority::UseCase::GetBaseReturn
   end
 
   def execute(project_id:)
-    return_data = @get_returns.execute(project_id: project_id).dig(:returns, -1, :updates, -1)
+    return_data = get_return_data_for_project(project_id)
     project = @project_gateway.find_by(id: project_id)
     schema = @return_gateway.find_by(type: project.type)
-    if return_data.nil?
-      data = @populate_return_template.execute(type: project.type,
-        baseline_data: project.data)[:populated_data]
-    else
-      data = @populate_return_template.execute(type: project.type,
-        baseline_data: project.data, return_data: return_data)[:populated_data]
-    end
+    data = populate_return(project, return_data)
 
     { base_return: { id: project_id, data: data, schema: schema.schema } }
+  end
+
+  private
+
+  def project_has_returns?(return_data)
+    !return_data.nil?
+  end
+
+  def get_return_data_for_project(project_id)
+    @get_returns.execute(project_id: project_id).dig(:returns, -1, :updates, -1)
+  end
+
+  def populate_return(project, return_data)
+    if project_has_returns?(return_data)
+      @populate_return_template.execute(
+        type: project.type,
+        baseline_data: project.data,
+        return_data: return_data
+      )[:populated_data]
+    else
+      @populate_return_template.execute(
+        type: project.type,
+        baseline_data: project.data
+      )[:populated_data]
+    end
   end
 end

--- a/lib/local_authority/use_case/get_base_return.rb
+++ b/lib/local_authority/use_case/get_base_return.rb
@@ -24,7 +24,13 @@ class LocalAuthority::UseCase::GetBaseReturn
   end
 
   def get_return_data_for_project(project_id)
-    @get_returns.execute(project_id: project_id).dig(:returns, -1, :updates, -1)
+    submitted_returns = @get_returns.execute(
+      project_id: project_id
+    )[:returns]&.select do |return_data|
+      return_data[:status] == 'Submitted'
+    end
+
+    submitted_returns&.dig(-1, :updates, -1)
   end
 
   def populate_return(project, return_data)
@@ -34,7 +40,6 @@ class LocalAuthority::UseCase::GetBaseReturn
         baseline_data: project.data,
         return_data: return_data
       )[:populated_data]
-
     else
       @populate_return_template.execute(
         type: project.type,

--- a/lib/local_authority/use_case/get_schema_copy_paths.rb
+++ b/lib/local_authority/use_case/get_schema_copy_paths.rb
@@ -20,8 +20,8 @@ class LocalAuthority::UseCase::GetSchemaCopyPaths
         paths += descend_object(value[:items], node_path)
       end
 
-      unless value[:baselineKey].nil?
-        paths << { to: node_path, from: value[:baselineKey] }
+      unless value[:sourceKey].nil?
+        paths << { to: node_path, from: value[:sourceKey] }
       end
     end
     paths

--- a/lib/local_authority/use_case/populate_return_template.rb
+++ b/lib/local_authority/use_case/populate_return_template.rb
@@ -67,12 +67,14 @@ class LocalAuthority::UseCase::PopulateReturnTemplate
   end
 
   def descend_array(hash, path, path_types, value)
-    hash[path.first] = descend_array_and_bury(
-      hash[path.first],
-      path.drop(1),
-      path_types.drop(1),
-      value
-    )
+    if value.class == Array
+      hash[path.first] = descend_array_and_bury(
+        hash[path.first],
+        path.drop(1),
+        path_types.drop(1),
+        value
+      )
+    end
   end
 
   def descend_hash(hash, path, path_types, value)
@@ -116,7 +118,12 @@ class LocalAuthority::UseCase::PopulateReturnTemplate
     elsif schema[:type] == 'array'
       [:array] + schema_types(schema[:items][:properties][path[0]], path.drop(1))
     elsif schema[:type] == 'object'
-      [:object] + schema_types(schema[:properties][path[0]], path.drop(1))
+      acquired_path = schema_types(schema[:properties][path[0]], path.drop(1))
+      if acquired_path.nil?
+        [:object]
+      else
+        [:object] + acquired_path
+      end
     end
   end
 end

--- a/lib/local_authority/use_cases.rb
+++ b/lib/local_authority/use_cases.rb
@@ -55,7 +55,8 @@ class LocalAuthority::UseCases
       LocalAuthority::UseCase::GetBaseReturn.new(
         return_gateway: builder.get_use_case(:return_template_gateway),
         project_gateway: builder.get_use_case(:project_gateway),
-        populate_return_template: builder.get_use_case(:populate_return_template)
+        populate_return_template: builder.get_use_case(:populate_return_template),
+        get_returns: builder.get_use_case(:get_returns)
       )
     end
 

--- a/lib/local_authority/use_cases.rb
+++ b/lib/local_authority/use_cases.rb
@@ -33,8 +33,8 @@ class LocalAuthority::UseCases
     end
 
 
-    builder.define_use_case :find_baseline_path do
-      LocalAuthority::UseCase::FindBaselinePath.new
+    builder.define_use_case :find_path_data do
+      LocalAuthority::UseCase::FindPathData.new
     end
 
     builder.define_use_case :get_schema_copy_paths do
@@ -46,7 +46,7 @@ class LocalAuthority::UseCases
     builder.define_use_case :populate_return_template do
       LocalAuthority::UseCase::PopulateReturnTemplate.new(
         template_gateway: builder.get_use_case(:return_template_gateway),
-        find_baseline_path: builder.get_use_case(:find_baseline_path),
+        find_path_data: builder.get_use_case(:find_path_data),
         get_schema_copy_paths: builder.get_use_case(:get_schema_copy_paths)
       )
     end

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -540,6 +540,12 @@ describe 'Performing Return on HIF Project' do
     submit_return(id: return_id)
     expect_return_to_be_submitted(id: return_id)
 
+    #A draft
+    create_new_return(
+      project_id: initial_return[:project_id],
+      data: initial_return[:data]
+    )
+
     second_base_return = get_use_case(:get_base_return).execute(project_id: project_id)
     expect(second_base_return[:base_return][:data]).to eq(expected_second_base_return[:data])
   end

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -396,6 +396,53 @@ describe 'Performing Return on HIF Project' do
 
     submit_return(id: return_id)
     expect_return_to_be_submitted(id: return_id)
+
+    second_return = {
+      project_id: project_id,
+      data: {
+        summary: {
+          project_name: 'Dogs Protection League',
+          description: 'A new headquarters for all the Dogs',
+          lead_authority: 'Made Tech'
+        },
+        infrastructure: {
+          type: 'Dog Bathroom',
+          description: 'Bathroom for Dogs',
+          completion_date: '2018-12-25',
+          planning: {
+            submission_estimated: '2018-06-01',
+            submission_actual: '2018-07-01',
+            submission_delay_reason: 'Planning office was closed for summer'
+          }
+        },
+        financial: {
+          total_amount_estimated: '£ 1000000.00',
+          total_amount_actual: nil,
+          total_amount_changed_reason: nil
+        }
+      }
+    }
+
+    second_return_id = create_new_return(
+      project_id: second_return[:project_id],
+      data: initial_return[:data]
+    )
+
+    expected_second_return = {
+      project_id: project_id,
+      status: 'Draft',
+      updates: [
+        second_return[:data]
+      ]
+    }
+
+    expect_return_with_id_to_equal(
+      id: second_return_id,
+      expected_return: expected_second_return
+    )
+
+    submit_return(id: second_return_id)
+    expect_return_to_be_submitted(id: second_return_id)
   end
 
   def soft_update_return(id:, data:)

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -425,7 +425,7 @@ describe 'Performing Return on HIF Project' do
 
     second_return_id = create_new_return(
       project_id: second_return[:project_id],
-      data: initial_return[:data]
+      data: second_return[:data]
     )
 
     expected_second_return = {

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -295,6 +295,136 @@ describe 'Performing Return on HIF Project' do
     }
   end
 
+  let(:expected_second_base_return) do
+    {
+      id: project_id,
+      data:
+      {
+        infrastructures: [
+          {
+            type: 'A House',
+            description: 'A house of cats',
+            planning: {
+              baselineOutlinePlanningPermissionGranted: true,
+              planningNotGranted: {
+                baselineSummaryOfCriticalPath: 'Summary of critical path',
+                fieldOne: {
+                  baselineCompletion: {
+                    baselineFullPlanningPermissionSubmitted: '2020-01-01',
+                    baselineFullPlanningPermissionGranted: '2020-01-01'
+                  },
+                  fullPlanningPermissionGranted: false,
+                  fullPlanningPermissionSummaryOfCriticalPath: 'Summary of critical path'
+                },
+                fieldTwo: {
+                  baselineCompletion: {
+                    baselineFullPlanningPermissionSubmitted: '2020-01-01',
+                    baselineFullPlanningPermissionGranted: '2020-01-01'
+                  }
+                },
+                s106Requirement: true,
+                s106SummaryOfRequirement: 'Required',
+                statutoryConsents: {
+                  anyStatutoryConsents: true
+                }
+              }
+            },
+            landOwnership: {
+              laHasControlOfSite: true,
+              laDoesNotControlSite: {
+                whoOwnsSite: 'Dave',
+                landAquisitionRequired: true
+              },
+              laDoesHaveControlOfSite: {
+                howManySitesToAquire: 10,
+                toBeAquiredBy: 'Dave',
+                summaryOfAcquisitionRequired: 'Summary of critical path',
+                allLandAssemblyAchieved: {
+                  landAssemblyBaselineCompletion: '2020-01-01'
+                }
+              }
+            },
+            procurement: {
+              contractorProcured: true,
+              infrastructureNotProcured: {
+                infraStructureContractorProcurement: {
+                  procurementBaselineCompletion: '2020-01-01'
+                }
+              },
+              infrastructureProcured: {
+                nameOfContractor: 'Dave'
+              }
+            },
+            milestones: {
+              keyMilestones: [{ milestoneBaselineCompletion: '2020-01-01',
+                                milestoneSummaryOfCriticalPath: 'Summary of critical path' }],
+              expectedInfrastructureStartOnSite: {
+                milestoneExpectedInfrastructureStartBaseline: '2020-01-01'
+              },
+              expectedCompletionDateOfInfra: {
+                milestoneExpectedInfrastructureCompletionBaseline: '2020-01-01'
+              }
+            },
+            risks: {
+              baselineRisks: {
+                risks: [{ items: {
+                  riskBaselineRisk: 'Risk one',
+                  riskBaselineImpact: 'High',
+                  riskBaselineLikelihood: 'High',
+                  riskBaselineMitigationsInPlace: 'Do not do the thing'
+                } }]
+              }
+            }
+          }
+        ],
+        funding: [
+          { hifFundingProfile: [
+            {
+              fundingYear: ['4000'],
+              forecast: {
+                forecastQ1: ['1000'],
+                forecastQ2: ['1000'],
+                forecastQ3: ['1000'],
+                forecastQ4: ['1000'],
+                forecastTotal: ['1000']
+              }
+            }
+          ],
+            fundingPackages: [
+              {
+                fundingPackage: {
+                  overview: {
+                    overviewCosts: {
+                      baselineCost: '1000'
+                    },
+                    hifSpendSinceLastReturn: {
+                      hifSpendLastReturn: '25565'
+                    }
+                  },
+                  fundingStack: {
+                    totallyFundedThroughHIF: true,
+                    notFundedThroughHif: {
+                      descriptionOfFundingStack: 'Stack',
+                      totalPublic: {
+                        publicTotalBaselineAmount: '2000'
+                      },
+                      totalPrivate: {
+                        privateTotalBaselineAmount: '2000'
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            recovery: {
+              aimToRecover: true
+            } }
+        ]
+      }
+    }
+  end
+
+
   let(:project_id) do
     get_use_case(:create_new_project).execute(
       type: 'hif', baseline: project_baseline
@@ -369,6 +499,19 @@ describe 'Performing Return on HIF Project' do
           submission_delay_reason: 'Planning office was closed for summer'
         }
       },
+      funding: [
+        {
+          fundingPackages: [
+            fundingPackage: {
+              overview: {
+                hifSpendSinceLastReturn: {
+                  hifSpendCurrentReturn: '25565'
+                }
+              }
+            }
+          ]
+        }
+      ],
       financial: {
         total_amount_estimated: '£ 1000000.00',
         total_amount_actual: nil,
@@ -397,52 +540,8 @@ describe 'Performing Return on HIF Project' do
     submit_return(id: return_id)
     expect_return_to_be_submitted(id: return_id)
 
-    second_return = {
-      project_id: project_id,
-      data: {
-        summary: {
-          project_name: 'Dogs Protection League',
-          description: 'A new headquarters for all the Dogs',
-          lead_authority: 'Made Tech'
-        },
-        infrastructure: {
-          type: 'Dog Bathroom',
-          description: 'Bathroom for Dogs',
-          completion_date: '2018-12-25',
-          planning: {
-            submission_estimated: '2018-06-01',
-            submission_actual: '2018-07-01',
-            submission_delay_reason: 'Planning office was closed for summer'
-          }
-        },
-        financial: {
-          total_amount_estimated: '£ 1000000.00',
-          total_amount_actual: nil,
-          total_amount_changed_reason: nil
-        }
-      }
-    }
-
-    second_return_id = create_new_return(
-      project_id: second_return[:project_id],
-      data: second_return[:data]
-    )
-
-    expected_second_return = {
-      project_id: project_id,
-      status: 'Draft',
-      updates: [
-        second_return[:data]
-      ]
-    }
-
-    expect_return_with_id_to_equal(
-      id: second_return_id,
-      expected_return: expected_second_return
-    )
-
-    submit_return(id: second_return_id)
-    expect_return_to_be_submitted(id: second_return_id)
+    second_base_return = get_use_case(:get_base_return).execute(project_id: project_id)
+    expect(second_base_return[:base_return][:data]).to eq(expected_second_base_return[:data])
   end
 
   def soft_update_return(id:, data:)

--- a/spec/unit/local_authority/use_case/find_path_data_spec.rb
+++ b/spec/unit/local_authority/use_case/find_path_data_spec.rb
@@ -1,4 +1,4 @@
-describe LocalAuthority::UseCase::FindBaselinePath do
+describe LocalAuthority::UseCase::FindPathData do
 
   let(:use_case) { described_class.new.execute(baseline_data, path) }
 

--- a/spec/unit/local_authority/use_case/find_path_data_spec.rb
+++ b/spec/unit/local_authority/use_case/find_path_data_spec.rb
@@ -131,4 +131,16 @@ describe LocalAuthority::UseCase::FindPathData do
       expect(use_case).to eq(found: [["Milestone One", "Milestone Two"]])
     end
   end
+
+  context 'non-existent path' do
+    let(:baseline_data) do
+      {
+        infrastructures: []
+      }
+    end
+    let(:path) { [:infrastructures, :milestones, :descriptionOfMilestone] }
+    it 'finds nothing' do
+      expect(use_case).to eq({})
+    end
+  end
 end

--- a/spec/unit/local_authority/use_case/get_base_return_spec.rb
+++ b/spec/unit/local_authority/use_case/get_base_return_spec.rb
@@ -1,5 +1,3 @@
-
-#We now need to get the last update and factor it into our populate
 describe LocalAuthority::UseCase::GetBaseReturn do
   let(:return_gateway) { spy(find_by: schema) }
   let(:project_gateway_spy) { spy(find_by: project) }

--- a/spec/unit/local_authority/use_case/get_base_return_spec.rb
+++ b/spec/unit/local_authority/use_case/get_base_return_spec.rb
@@ -254,6 +254,53 @@ describe LocalAuthority::UseCase::GetBaseReturn do
         )
       end
 
+      context 'draft returns' do
+        let(:returned_return) do
+          {
+            id: 0,
+            project_id: project_id,
+            status: 'Submitted',
+            updates: [
+              {
+                duck: 'Quack'
+              }
+            ]
+          }
+        end
+
+        let(:second_returned_return) do
+          {
+            id: 1,
+            project_id: project_id,
+            status: 'Draft',
+            updates: [
+              {
+                cow: 'Moo'
+              }
+            ]
+          }
+        end
+
+        let(:get_returns_spy) do
+          spy(execute:
+              {
+                returns:
+                [
+                  returned_return,
+                  second_returned_return
+                ]
+              })
+        end
+
+        it 'executes the populate return template use case' do
+          expect(populate_return_spy).to have_received(:execute).with(
+            type: project.type,
+            baseline_data: project.data,
+            return_data: returned_return[:updates][-1]
+          )
+        end
+      end
+
       context 'multiple returns' do
         let(:returned_return) do
           {

--- a/spec/unit/local_authority/use_case/get_base_return_spec.rb
+++ b/spec/unit/local_authority/use_case/get_base_return_spec.rb
@@ -19,85 +19,87 @@ describe LocalAuthority::UseCase::GetBaseReturn do
 
   before { response }
 
-  context 'example one' do
-    let(:schema) do
-      LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
-        p.schema = {cats: 'meow'}
+  context 'projects with single returns' do
+    context 'example one' do
+      let(:schema) do
+        LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
+          p.schema = {cats: 'meow'}
+        end
+      end
+      let(:project_id) { 1 }
+      let(:data) { { description: 'Super secret project' } }
+      let(:project) do
+        HomesEngland::Domain::Project.new.tap do |p|
+          p.type = 'hif'
+          p.data = data
+        end
+      end
+      let(:populated_return) { { populated_data: { cats: 'meow' } } }
+
+      it 'will find the project in the Project Gateway' do
+        expect(project_gateway_spy).to have_received(:find_by).with(id: project_id)
+      end
+
+      it 'will call find_by method on Return Gateway' do
+        expect(return_gateway).to have_received(:find_by).with(type: project.type)
+      end
+
+      it 'will populate the return for the project' do
+        expect(populate_return_spy).to have_received(:execute).with(type: project.type, baseline_data: project.data)
+      end
+
+      it 'will return a hash with correct id' do
+        expect(use_case.execute(project_id: project_id)[:base_return]).to include(id: project_id)
+      end
+
+      it 'will return a hash with the populated return data' do
+        expect(use_case.execute(project_id: project_id)[:base_return]).to include(data: { cats: 'meow' })
+      end
+
+      it 'will return a hash with correct schema' do
+        expect(use_case.execute(project_id: project_id)[:base_return]).to include(schema: schema.schema)
       end
     end
-    let(:project_id) { 1 }
-    let(:data) { { description: 'Super secret project' } }
-    let(:project) do
-      HomesEngland::Domain::Project.new.tap do |p|
-        p.type = 'hif'
-        p.data = data
+
+    context 'example two' do
+      let(:schema) { LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
+        p.schema = {dogs: 'woof'}
       end
-    end
-    let(:populated_return) { { populated_data: { cats: 'meow' } } }
-
-    it 'will find the project in the Project Gateway' do
-      expect(project_gateway_spy).to have_received(:find_by).with(id: project_id)
-    end
-
-    it 'will call find_by method on Return Gateway' do
-      expect(return_gateway).to have_received(:find_by).with(type: project.type)
-    end
-
-    it 'will populate the return for the project' do
-      expect(populate_return_spy).to have_received(:execute).with(type: project.type, baseline_data: project.data)
-    end
-
-    it 'will return a hash with correct id' do
-      expect(use_case.execute(project_id: project_id)[:base_return]).to include(id: project_id)
-    end
-
-    it 'will return a hash with the populated return data' do
-      expect(use_case.execute(project_id: project_id)[:base_return]).to include(data: { cats: 'meow' })
-    end
-
-    it 'will return a hash with correct schema' do
-      expect(use_case.execute(project_id: project_id)[:base_return]).to include(schema: schema.schema)
-    end
-  end
-
-  context 'example two' do
-    let(:schema) { LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
-      p.schema = {dogs: 'woof'}
-    end
-    }
-    let(:project_id) { 255 }
-    let(:data) { { name: 'Extra secret project' } }
-    let(:project) do
-      HomesEngland::Domain::Project.new.tap do |p|
-        p.type = 'hif'
-        p.data = data
+      }
+      let(:project_id) { 255 }
+      let(:data) { { name: 'Extra secret project' } }
+      let(:project) do
+        HomesEngland::Domain::Project.new.tap do |p|
+          p.type = 'hif'
+          p.data = data
+        end
       end
-    end
-    let(:populated_return) { { populated_data: { cows: 'moo' } } }
+      let(:populated_return) { { populated_data: { cows: 'moo' } } }
 
 
-    it 'will find the project in the Project Gateway' do
-      expect(project_gateway_spy).to have_received(:find_by).with(id: project_id)
-    end
+      it 'will find the project in the Project Gateway' do
+        expect(project_gateway_spy).to have_received(:find_by).with(id: project_id)
+      end
 
-    it 'will call find_by method on Return Gateway' do
-      expect(return_gateway).to have_received(:find_by).with(type: project.type)
-    end
+      it 'will call find_by method on Return Gateway' do
+        expect(return_gateway).to have_received(:find_by).with(type: project.type)
+      end
 
-    it 'will populate the return for the project' do
-      expect(populate_return_spy).to have_received(:execute).with(type: project.type, baseline_data: project.data)
-    end
+      it 'will populate the return for the project' do
+        expect(populate_return_spy).to have_received(:execute).with(type: project.type, baseline_data: project.data)
+      end
 
-    it 'will return a hash with correct id' do
-      expect(use_case.execute(project_id: project_id)[:base_return]).to include(id: project_id)
-    end
+      it 'will return a hash with correct id' do
+        expect(use_case.execute(project_id: project_id)[:base_return]).to include(id: project_id)
+      end
 
-    it 'will return a hash with the populated return' do
-      expect(use_case.execute(project_id: project_id)[:base_return]).to include(data: { cows: 'moo' })
-    end
+      it 'will return a hash with the populated return' do
+        expect(use_case.execute(project_id: project_id)[:base_return]).to include(data: { cows: 'moo' })
+      end
 
-    it 'will return a hash with correct schema' do
-      expect(use_case.execute(project_id: project_id)[:base_return]).to include(schema: schema.schema)
+      it 'will return a hash with correct schema' do
+        expect(use_case.execute(project_id: project_id)[:base_return]).to include(schema: schema.schema)
+      end
     end
   end
 

--- a/spec/unit/local_authority/use_case/get_base_return_spec.rb
+++ b/spec/unit/local_authority/use_case/get_base_return_spec.rb
@@ -1,8 +1,10 @@
 
+#We now need to get the last update and factor it into our populate
 describe LocalAuthority::UseCase::GetBaseReturn do
-  let(:return_gateway) {spy(find_by: schema)}
+  let(:return_gateway) { spy(find_by: schema) }
   let(:project_gateway_spy) { spy(find_by: project) }
   let(:populate_return_spy) { spy(execute: populated_return) }
+
   let(:use_case) do
     described_class.new(
       return_gateway: return_gateway,

--- a/spec/unit/local_authority/use_case/get_base_return_spec.rb
+++ b/spec/unit/local_authority/use_case/get_base_return_spec.rb
@@ -1,18 +1,18 @@
 
 #We now need to get the last update and factor it into our populate
-describe LocalAuthority::UseCase::GetBaseReturn, focus: true do
+describe LocalAuthority::UseCase::GetBaseReturn do
   let(:return_gateway) { spy(find_by: schema) }
   let(:project_gateway_spy) { spy(find_by: project) }
   let(:populate_return_spy) { spy(execute: populated_return) }
 
-  let(:get_returns) { spy(execute: {}) }
+  let(:get_returns_spy) { spy(execute: {}) }
 
   let(:use_case) do
     described_class.new(
       return_gateway: return_gateway,
       project_gateway: project_gateway_spy,
       populate_return_template: populate_return_spy,
-      get_returns: get_returns
+      get_returns: get_returns_spy
     )
   end
   let(:response) { use_case.execute(project_id: project_id) }
@@ -108,7 +108,6 @@ describe LocalAuthority::UseCase::GetBaseReturn, focus: true do
       end
     end
 
-    let(:project_id) { 1 }
     let(:data) { { description: 'Super secret project' } }
 
     let(:project) do
@@ -118,21 +117,7 @@ describe LocalAuthority::UseCase::GetBaseReturn, focus: true do
       end
     end
 
-    let(:returned_return) do
-      {
-        id: 0,
-        project_id: project_id,
-        status: 'Submitted',
-        updates: [
-          {
-            cat: 'Meow'
-          }
-        ]
-      }
-    end
-
-    #get_returns is executed by .execute(project_id:)
-    let(:get_returns) do
+    let(:get_returns_spy) do
       spy(execute:
           {
             returns:
@@ -144,8 +129,202 @@ describe LocalAuthority::UseCase::GetBaseReturn, focus: true do
 
     let(:populated_return) { { populated_data: { cat: 'Meow' } } }
 
-    #Need to ensure we
-    # 1. Execute get_returns
-    # 2. Execute populate_data with return_data as well as baseline_data
+    context 'example 1' do
+      let(:returned_return) do
+        {
+          id: 0,
+          project_id: project_id,
+          status: 'Submitted',
+          updates: [
+            {
+              cat: 'Meow'
+            }
+          ]
+        }
+      end
+      let(:project_id) { 1 }
+      it 'executes the get returns use case with the project id' do
+        expect(get_returns_spy).to have_received(:execute).with(project_id: 1)
+      end
+
+      it 'executes the populate return template use case with data from a return' do
+        expect(populate_return_spy).to have_received(:execute).with(
+          type: project.type,
+          baseline_data: project.data,
+          return_data: returned_return[:updates][-1]
+        )
+      end
+
+      context 'multiple returns' do
+        let(:returned_return) do
+          {
+            id: 0,
+            project_id: project_id,
+            status: 'Submitted',
+            updates: [
+              {
+                dog: 'Woof'
+              }
+            ]
+          }
+        end
+
+        let(:second_returned_return) do
+          {
+            id: 1,
+            project_id: project_id,
+            status: 'Submitted',
+            updates: [
+              {
+                cat: 'Meow'
+              }
+            ]
+          }
+        end
+
+        let(:get_returns_spy) do
+          spy(execute:
+              {
+                returns:
+                [
+                  returned_return,
+                  second_returned_return
+                ]
+              })
+        end
+
+        it 'executes the populate return template use case' do
+          expect(populate_return_spy).to have_received(:execute).with(
+            type: project.type,
+            baseline_data: project.data,
+            return_data: second_returned_return[:updates][-1]
+          )
+        end
+
+        context 'multiple updates' do
+          let(:second_returned_return) do
+            {
+              id: 1,
+              project_id: project_id,
+              status: 'Submitted',
+              updates: [
+                {
+                  bird: 'tweet'
+                },
+                {
+                  alpaca: 'Hum'
+                }
+              ]
+            }
+          end
+          it 'executes the populate return template use case' do
+            expect(populate_return_spy).to have_received(:execute).with(
+              type: project.type,
+              baseline_data: project.data,
+              return_data: second_returned_return[:updates][-1]
+            )
+          end
+        end
+      end
+    end
+
+    context 'example 2' do
+      let(:returned_return) do
+        {
+          id: 0,
+          project_id: project_id,
+          status: 'Submitted',
+          updates: [
+            {
+              dog: 'Woof'
+            }
+          ]
+        }
+      end
+      let(:project_id) { 3 }
+      it 'executes the get returns use case with the project id' do
+        expect(get_returns_spy).to have_received(:execute).with(project_id: 3)
+      end
+
+      it 'executes the populate return template use case with data from a return' do
+        expect(populate_return_spy).to have_received(:execute).with(
+          type: project.type,
+          baseline_data: project.data,
+          return_data: returned_return[:updates][-1]
+        )
+      end
+
+      context 'multiple returns' do
+        let(:returned_return) do
+          {
+            id: 0,
+            project_id: project_id,
+            status: 'Submitted',
+            updates: [
+              {
+                duck: 'Quack'
+              }
+            ]
+          }
+        end
+
+        let(:second_returned_return) do
+          {
+            id: 1,
+            project_id: project_id,
+            status: 'Submitted',
+            updates: [
+              {
+                cow: 'Moo'
+              }
+            ]
+          }
+        end
+
+        let(:get_returns_spy) do
+          spy(execute:
+              {
+                returns:
+                [
+                  returned_return,
+                  second_returned_return
+                ]
+              })
+        end
+
+        it 'executes the populate return template use case' do
+          expect(populate_return_spy).to have_received(:execute).with(
+            type: project.type,
+            baseline_data: project.data,
+            return_data: second_returned_return[:updates][-1]
+          )
+        end
+
+        context 'multiple updates' do
+          let(:second_returned_return) do
+            {
+              id: 1,
+              project_id: project_id,
+              status: 'Submitted',
+              updates: [
+                {
+                  guppy: 'Pop'
+                },
+                {
+                  llama: 'Buzz'
+                }
+              ]
+            }
+          end
+          it 'executes the populate return template use case' do
+            expect(populate_return_spy).to have_received(:execute).with(
+              type: project.type,
+              baseline_data: project.data,
+              return_data: second_returned_return[:updates][-1]
+            )
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/unit/local_authority/use_case/get_base_return_spec.rb
+++ b/spec/unit/local_authority/use_case/get_base_return_spec.rb
@@ -1,15 +1,18 @@
 
 #We now need to get the last update and factor it into our populate
-describe LocalAuthority::UseCase::GetBaseReturn do
+describe LocalAuthority::UseCase::GetBaseReturn, focus: true do
   let(:return_gateway) { spy(find_by: schema) }
   let(:project_gateway_spy) { spy(find_by: project) }
   let(:populate_return_spy) { spy(execute: populated_return) }
+
+  let(:get_returns) { spy(execute: {}) }
 
   let(:use_case) do
     described_class.new(
       return_gateway: return_gateway,
       project_gateway: project_gateway_spy,
-      populate_return_template: populate_return_spy
+      populate_return_template: populate_return_spy,
+      get_returns: get_returns
     )
   end
   let(:response) { use_case.execute(project_id: project_id) }
@@ -48,7 +51,7 @@ describe LocalAuthority::UseCase::GetBaseReturn do
       expect(use_case.execute(project_id: project_id)[:base_return]).to include(id: project_id)
     end
 
-    it 'will return a hash with populated return data' do
+    it 'will return a hash with the populated return data' do
       expect(use_case.execute(project_id: project_id)[:base_return]).to include(data: { cats: 'meow' })
     end
 
@@ -89,12 +92,60 @@ describe LocalAuthority::UseCase::GetBaseReturn do
       expect(use_case.execute(project_id: project_id)[:base_return]).to include(id: project_id)
     end
 
-    it 'will return a hash with populated baseline' do
+    it 'will return a hash with the populated return' do
       expect(use_case.execute(project_id: project_id)[:base_return]).to include(data: { cows: 'moo' })
     end
 
     it 'will return a hash with correct schema' do
       expect(use_case.execute(project_id: project_id)[:base_return]).to include(schema: schema.schema)
     end
+  end
+
+  context 'with previous returns' do
+    let(:schema) do
+      LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
+        p.schema = {cats: 'meow'}
+      end
+    end
+
+    let(:project_id) { 1 }
+    let(:data) { { description: 'Super secret project' } }
+
+    let(:project) do
+      HomesEngland::Domain::Project.new.tap do |p|
+        p.type = 'hif'
+        p.data = data
+      end
+    end
+
+    let(:returned_return) do
+      {
+        id: 0,
+        project_id: project_id,
+        status: 'Submitted',
+        updates: [
+          {
+            cat: 'Meow'
+          }
+        ]
+      }
+    end
+
+    #get_returns is executed by .execute(project_id:)
+    let(:get_returns) do
+      spy(execute:
+          {
+            returns:
+            [
+              returned_return
+            ]
+          })
+    end
+
+    let(:populated_return) { { populated_data: { cat: 'Meow' } } }
+
+    #Need to ensure we
+    # 1. Execute get_returns
+    # 2. Execute populate_data with return_data as well as baseline_data
   end
 end

--- a/spec/unit/local_authority/use_case/get_schema_copy_paths_spec.rb
+++ b/spec/unit/local_authority/use_case/get_schema_copy_paths_spec.rb
@@ -12,7 +12,7 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
           {
             noise:
             {
-              baselineKey: [:cats]
+              sourceKey: [:cats]
             }
           }
         }
@@ -30,7 +30,7 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
           {
             sounds:
             {
-              baselineKey: [:dogs]
+              sourceKey: [:dogs]
             }
           }
         }
@@ -47,13 +47,13 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
         type: 'object',
         properties: {
           catNoise: {
-            baselineKey: [:cats]
+            sourceKey: [:cats]
           },
           dogNoise: {
-            baselineKey: [:dogs]
+            sourceKey: [:dogs]
           },
           cowNoise: {
-            baselineKey: [:cows]
+            sourceKey: [:cows]
           }
         }
       }
@@ -73,12 +73,12 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
         type: 'object',
         properties: {
           catNoise: {
-            baselineKey: [:cats]
+            sourceKey: [:cats]
           },
           dogNoise: {
           },
           cowNoise: {
-            baselineKey: [:cows]
+            sourceKey: [:cows]
           }
         }
       }
@@ -100,7 +100,7 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
             type: 'object',
             properties: {
               breed: {
-                baselineKey: [:breed]
+                sourceKey: [:breed]
               }
             }
           }
@@ -127,7 +127,7 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
                 type: 'object',
                 properties: {
                   breed: {
-                    baselineKey: [:parentA]
+                    sourceKey: [:parentA]
                   }
                 }
               },
@@ -135,7 +135,7 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
                 type: 'object',
                 properties: {
                   breed: {
-                    baselineKey: [:parentB]
+                    sourceKey: [:parentB]
                   }
                 }
               }
@@ -167,7 +167,7 @@ describe LocalAuthority::UseCase::GetSchemaCopyPaths do
               properties:
               {
                 breed: {
-                  baselineKey: [:breed]
+                  sourceKey: [:breed]
                 }
               }
             }

--- a/spec/unit/local_authority/use_case/populate_return_template_spec.rb
+++ b/spec/unit/local_authority/use_case/populate_return_template_spec.rb
@@ -450,4 +450,76 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
       expect(result).to eq(populated_data: { cat: "Meow" })
     end
   end
+
+  context 'creating a return to a non-existent simple two level path' do
+    let(:template_schema) do
+      {
+        type: 'object',
+        properties:
+        {
+          cat:
+          {
+            sourceKey: [:return_data, :cats, :name]
+          }
+        }
+      }
+    end
+
+    let(:baseline_data) { {} }
+    let(:return_data) { {cats: []} }
+
+    let(:copy_paths) do
+        {
+          paths:
+          [
+            {from: [:return_data, :cats, :name], to: [:cat,:something]}
+          ]
+        }
+    end
+
+    it 'gives an empty populated_data' do
+      result = use_case.execute(type: 'hif', baseline_data: baseline_data, return_data: return_data)
+      expect(result).to eq(populated_data: {})
+    end
+  end
+
+  context 'creating a return with a non-existent source path that contains an array' do
+    let(:template_schema) do
+      {
+        type: 'object',
+        properties:
+        {
+          cats:
+          {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                cat: {
+                  sourceKey: [:return_data, :cats, :name]
+                }
+              }
+            }
+          }
+        }
+      }
+    end
+
+    let(:baseline_data) { {} }
+    let(:return_data) { {cats: []} }
+
+    let(:copy_paths) do
+        {
+          paths:
+          [
+            {from: [:return_data, :cats, :name], to: [:cats,:cat]}
+          ]
+        }
+    end
+
+    it 'gives an empty populated_data' do
+      result = use_case.execute(type: 'hif', baseline_data: baseline_data, return_data: return_data)
+      expect(result).to eq(populated_data: {cats: []})
+    end
+  end
 end

--- a/spec/unit/local_authority/use_case/populate_return_template_spec.rb
+++ b/spec/unit/local_authority/use_case/populate_return_template_spec.rb
@@ -11,11 +11,11 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
     end
   end
   let(:template_gateway) { spy(find_by: found_template) }
-  let(:find_baseline_path) { spy(execute: { found: matching_baseline_data }) }
+  let(:find_path_data) { spy(execute: { found: matching_baseline_data }) }
   let(:get_schema_copy_paths) { spy(execute: copy_paths) }
   let(:use_case) do
     described_class.new(template_gateway: template_gateway,
-    find_baseline_path: find_baseline_path,
+    find_path_data: find_path_data,
     get_schema_copy_paths: get_schema_copy_paths)
   end
 
@@ -179,7 +179,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
       }
     end
 
-    let(:find_baseline_path) do
+    let(:find_path_data) do
       Class.new do
         def execute(baseline_data, path)
           if path == [:cats, :sound]
@@ -276,7 +276,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
       {from: [:dogs, :sound], to: [:dog]}
     ] } }
 
-    let(:find_baseline_path) do
+    let(:find_path_data) do
       Class.new do
         def execute(baseline_data, path)
           if path == [:cats, :sound]

--- a/spec/unit/local_authority/use_case/populate_return_template_spec.rb
+++ b/spec/unit/local_authority/use_case/populate_return_template_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# No baselineKey?
-# Arrays
-
 describe LocalAuthority::UseCase::PopulateReturnTemplate do
   let(:template_schema) { { properties: {} } }
   let(:matching_baseline_data) { '' }
@@ -15,10 +12,12 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
   end
   let(:template_gateway) { spy(find_by: found_template) }
   let(:find_baseline_path) { spy(execute: { found: matching_baseline_data }) }
-  let(:get_schema_copy_paths) { spy(execute: copy_paths)}
-  let(:use_case) { described_class.new(template_gateway: template_gateway,
+  let(:get_schema_copy_paths) { spy(execute: copy_paths) }
+  let(:use_case) do
+    described_class.new(template_gateway: template_gateway,
     find_baseline_path: find_baseline_path,
-    get_schema_copy_paths: get_schema_copy_paths)}
+    get_schema_copy_paths: get_schema_copy_paths)
+  end
 
 
   context 'finds the template' do
@@ -93,18 +92,18 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
         {
           noise:
           {
-            baselineKey: [:cats]
+            sourceKey: [:baseline_data, :cats]
           }
         }
       }
     end
 
     let(:matching_baseline_data) { "Meow" }
-    let(:copy_paths) { { paths: [{from: [:cats], to: [:noise]}] } }
+    let(:copy_paths) { { paths: [{ from: [:cats], to: [:noise] }] } }
 
     it 'populates a simple template' do
       result = use_case.execute(type: 'hif', baseline_data: baseline_data)
-      expect(result).to eq(populated_data: {noise: "Meow"})
+      expect(result).to eq(populated_data: { noise: "Meow" })
     end
   end
 
@@ -126,7 +125,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
         {
           noise:
           {
-            baselineKey: [:cats, :sound]
+            sourceKey: [:baseline_data, :cats, :sound]
           }
         }
       }
@@ -166,11 +165,11 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
               {
                 noise:
                 {
-                  baselineKey: [:cats, :sound]
+                  sourceKey: [:baseline_data, :cats, :sound]
                 },
                 breed:
                 {
-                  baselineKey: [:cats, :breed]
+                  sourceKey: [:baseline_data, :cats, :breed]
                 }
               }
             }
@@ -223,7 +222,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
             properties:
             {
               cat: {
-                baselineKey: [:cats, :sound]
+                sourceKey: [:baseline_data, :cats, :sound]
               }
             }
           }
@@ -263,11 +262,11 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
         {
           cat:
           {
-            baselineKey: [:cats, :sound]
+            sourceKey: [:baseline_data, :cats, :sound]
           },
           dog:
           {
-            baselineKey: [:dogs, :sound]
+            sourceKey: [:baseline_data, :dogs, :sound]
           }
         }
       }
@@ -319,7 +318,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
                 properties:
                 {
                   noise: {
-                    baselineKey: [:cats, :sound]
+                    sourceKey: [:baseline_data, :cats, :sound]
                   }
                 }
               }
@@ -372,7 +371,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
                       {
                         sounds:
                         {
-                          baselineKey: [:cats, :sounds]
+                          sourceKey: [:baseline_data, :cats, :sounds]
                         }
                       }
                     }
@@ -411,6 +410,44 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
         ]
       }}
       )
+    end
+  end
+
+  context 'Creating a return from another return' do
+    let(:template_schema) do
+      {
+        type: 'object',
+        properties:
+        {
+          noise:
+          {
+            sourceKey: [:return_data, :cat]
+          }
+        }
+      }
+    end
+
+    let(:baseline_data) { {} }
+    let(:return_data) do
+      {
+        cat: "Meow"
+      }
+    end
+
+    let(:copy_paths) do
+        {
+          paths:
+          [
+            {from: [:return_data, :cat], to: [:cat]}
+          ]
+        }
+    end
+
+    let(:matching_baseline_data) { "Meow" }
+
+    it 'is a simple return' do
+      result = use_case.execute(type: 'hif', baseline_data: baseline_data, return_data: return_data)
+      expect(result).to eq(populated_data: { cat: "Meow" })
     end
   end
 end


### PR DESCRIPTION
What - Return schemas can now reference a path in the previous returns. The schema path format has changed slightly, it must now be prefixed with the data source for example `[:baseline_data, :cats]` vs `[:return_data, :dogs]` the schema key used to store this path has also changed from `:baselineKey` to `:sourceKey`. Note that there is not currently any way of referencing a specific return.  
  
Why - This is so that returns using relevant and up to date data can be created.